### PR TITLE
Prototype external transaction caching for discussion purposes.

### DIFF
--- a/electrumsv/commands.py
+++ b/electrumsv/commands.py
@@ -571,9 +571,10 @@ class Commands:
     @command('n')
     def gettransaction(self, txid):
         """Retrieve a transaction. """
-        if self.wallet and txid in self.wallet.transactions:
-            tx = self.wallet.transactions[txid]
-        else:
+        tx = None
+        if self.wallet:
+            tx = self.wallet.get_transaction(txid)
+        if tx is None:
             raw = self.network.request_and_wait('blockchain.transaction.get', [txid])
             if raw:
                 tx = Transaction(raw)

--- a/electrumsv/gui/qt/history_list.py
+++ b/electrumsv/gui/qt/history_list.py
@@ -126,7 +126,7 @@ class HistoryList(MyTreeWidget):
             super(HistoryList, self).on_doubleclick(item, column)
         else:
             tx_hash = item.data(0, Qt.UserRole)
-            tx = self.wallet.transactions.get(tx_hash)
+            tx = self.wallet.get_transaction(tx_hash)
             self.parent.show_transaction(tx)
 
     def update_labels(self):
@@ -166,7 +166,7 @@ class HistoryList(MyTreeWidget):
 
         tx_URL = web.BE_URL(self.config, 'tx', tx_hash)
         height, _conf, _timestamp = self.wallet.get_tx_height(tx_hash)
-        tx = self.wallet.transactions.get(tx_hash)
+        tx = self.wallet.get_transaction(tx_hash)
         if not tx: return # this happens sometimes on wallet synch when first starting up.
         # is_relevant, is_mine, v, fee = self.wallet.get_wallet_delta(tx)
         is_unconfirmed = height <= 0

--- a/electrumsv/gui/qt/transaction_dialog.py
+++ b/electrumsv/gui/qt/transaction_dialog.py
@@ -145,7 +145,7 @@ class TxDialog(QDialog, MessageBoxMixin):
             self.update()
 
     def update_tx_if_in_wallet(self):
-        if self.tx.txid() in self.wallet.transactions:
+        if self.wallet.has_received_transaction(self.tx.txid()):
             self.update()
 
     def do_broadcast(self):

--- a/electrumsv/gui/qt/utxo_list.py
+++ b/electrumsv/gui/qt/utxo_list.py
@@ -111,7 +111,7 @@ class UTXOList(MyTreeWidget):
             # "freeze" status, if any
             txid = list(selected.keys())[0].split(':')[0]
             frozen_flags = list(selected.values())[0]
-            tx = self.wallet.transactions.get(txid)
+            tx = self.wallet.get_transaction(txid)
             menu.addAction(_("Details"), lambda: self.parent.show_transaction(tx))
             needsep = True
             if 'c' in frozen_flags:

--- a/electrumsv/tests/test_transaction_store.py
+++ b/electrumsv/tests/test_transaction_store.py
@@ -1,0 +1,184 @@
+import os
+import tempfile
+import unittest
+
+import bitcoinx
+
+from electrumsv.transaction import Transaction
+from electrumsv import transaction_store
+
+tx_hex_1 = ("01000000011a284a701e6a69ba68ac4b1a4509ac04f5c10547e3165fe869d5e910fe91bc4c04000000"+
+    "6b483045022100e81ce3382de4d63efad1e2bc4a7ebe70fb03d8451c1bc176b2dfd310f7a636f302200eab4382"+
+    "9f9d4c94be41c640f9f6261657dcac6dc345718b89e7a80645dbe27f412102defddf740fa60b0dcdc88578d9de"+
+    "a51350db9245e4f1a5072be00e9fb0573fddffffffff02a0860100000000001976a914717b9a7840ef60ef2e2a"+
+    "6fca85d55988e070137988acda837e18000000001976a914c0eab5430fd02e18edfc28607eae975001e7560488"+
+    "ac00000000")
+
+class TestTransactionStore(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_filename = os.path.join(self.temp_dir.name, "test")
+        self.store = transaction_store.TransactionStore(self.db_filename)
+
+        self.tx_id = os.urandom(32).hex()
+
+    def tearDown(self):
+        self.store.close()
+
+    def test_create_db_passive(self):
+        # This has already run on TransactionStore creation. We test that it does not error being
+        # run again, if the database entities already exist.
+        self.store._create(self.store._get_db())
+
+    def test_has_for_missing_transaction(self):
+        self.assertFalse(self.store.has(self.tx_id))
+
+    def test_has_for_existing_transaction(self):
+        self.store.add(self.tx_id, os.urandom(100))
+        self.assertTrue(self.store.has(self.tx_id))
+
+    def test_add_bytes_transaction(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        tx_hex = tx_bytes.hex()
+        self.store.add(tx_id, tx_bytes)
+        tx = self.store.get(tx_id)
+        self.assertEqual(tx_hex, str(tx))
+
+    def test_add_string_transaction(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        tx_hex = tx_bytes.hex()
+        self.store.add(tx_id, tx_hex)
+        tx = self.store.get(tx_id)
+        self.assertEqual(tx_hex, str(tx))
+
+    def test_add_transaction_object(self):
+        tx_hex = tx_hex_1
+        tx_0 = Transaction(tx_hex)
+        tx_id_0 = tx_0.txid()
+        self.store.add(tx_id_0, tx_0)
+        tx_1 = self.store.get(tx_id_0)
+        self.assertEqual(tx_hex, str(tx_1))
+
+    def test_add_bad_transaction(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, bytes(reversed(tx_bytes)))
+        tx = self.store.get(tx_id)
+        self.assertTrue(tx is None)
+
+    def test_was_received(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes)
+        self.assertTrue(self.store.was_received(tx_id))
+
+    def test_was_received_when_pending(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes, is_pending=True)
+        self.assertFalse(self.store.was_received(self.tx_id))
+
+    def test_was_received_when_nonexistent(self):
+        self.assertFalse(self.store.was_received(self.tx_id))
+
+    def test_add_many_received(self):
+        tx_map = {}
+        for i in range(10):
+            tx_bytes = os.urandom(10)
+            tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+            tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+            tx_map[tx_id] = tx_bytes.hex()
+        self.store.add_many(tx_map)
+        received_tx_ids = self.store.get_received_ids()
+        added_tx_ids = set(tx_map)
+        self.assertEqual(received_tx_ids, added_tx_ids)
+
+    def test_add_many_pending(self):
+        tx_map = {}
+        for i in range(10):
+            tx_bytes = os.urandom(10)
+            tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+            tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+            tx_map[tx_id] = tx_bytes.hex()
+        self.store.add_many(tx_map, is_pending=True)
+        pending_tx_ids = self.store.get_pending_ids()
+        added_tx_ids = set(tx_map)
+        self.assertEqual(pending_tx_ids, added_tx_ids)
+
+    def test_delete(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes)
+        self.assertTrue(self.store.has(tx_id))
+        self.store.delete(tx_id)
+        self.assertFalse(self.store.has(tx_id))
+
+    def test_delete_many(self):
+        tx_map = {}
+        for i in range(10):
+            tx_bytes = os.urandom(10)
+            tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+            tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+            tx_map[tx_id] = tx_bytes.hex()
+        self.store.add_many(tx_map)
+        for tx_id in tx_map:
+            self.assertTrue(self.store.has(tx_id))
+        self.store.delete_many(list(tx_map))
+        for tx_id in tx_map:
+            self.assertFalse(self.store.has(tx_id))
+
+    def test_get_unfiltered_received(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes) # Add as received.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNotNone(self.store.get(tx_id))
+
+    def test_get_unfiltered_pending(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes, is_pending=True) # Add as pending.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNotNone(self.store.get(tx_id))
+
+    def test_get_filtered_pending_nonexistent(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes) # Add as received.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNone(self.store.get(tx_id, is_pending=True))
+
+    def test_get_filtered_pending(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes, is_pending=True) # Add as pending.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNotNone(self.store.get(tx_id, is_pending=True))
+
+    def test_get_filtered_received(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes) # Add as received.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNotNone(self.store.get(tx_id, is_pending=False))
+
+    def test_get_filtered_received_nonexistent(self):
+        tx_bytes = os.urandom(10)
+        tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+        tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+        self.store.add(tx_id, tx_bytes, is_pending=True) # Add as pending.
+        self.assertTrue(self.store.has(tx_id))
+        self.assertIsNone(self.store.get(tx_id, is_pending=False))

--- a/electrumsv/tests/test_transaction_store.py
+++ b/electrumsv/tests/test_transaction_store.py
@@ -30,6 +30,15 @@ class TestTransactionStore(unittest.TestCase):
         # run again, if the database entities already exist.
         self.store._create(self.store._get_db())
 
+    def test_count(self):
+        for i in range(3):
+            self.assertEqual(i, self.store.count())
+            tx_bytes = os.urandom(10)
+            tx_hash_bytes = bitcoinx.double_sha256(tx_bytes)
+            tx_id = bitcoinx.hash_to_hex_str(tx_hash_bytes)
+            self.store.add(tx_id, tx_bytes, is_pending=True) # Add as pending.
+        self.assertEqual(i+1, self.store.count())
+
     def test_has_for_missing_transaction(self):
         self.assertFalse(self.store.has(self.tx_id))
 

--- a/electrumsv/transaction_store.py
+++ b/electrumsv/transaction_store.py
@@ -43,6 +43,12 @@ class TransactionStore:
         self._state.db.close()
         self._state = None
 
+    def count(self):
+        db = self._get_db()
+        cursor = db.execute("SELECT COUNT(*) FROM Transactions")
+        row = cursor.fetchone()
+        return row[0]
+
     def has(self, tx_id: str) -> bool:
         db = self._get_db()
         cursor = db.execute("SELECT EXISTS(SELECT 1 FROM Transactions WHERE Key=?)", [tx_id])

--- a/electrumsv/transaction_store.py
+++ b/electrumsv/transaction_store.py
@@ -1,0 +1,78 @@
+import os
+from typing import Any
+
+from .bitcoin import sha256d
+from .app_state import app_state
+from .transaction import Transaction
+
+class TransactionStore:
+    def __init__(self, keys) -> None:
+        self._keys = frozenset(keys)
+        self._cache = {}
+        self._cache_path = os.path.join(app_state.config.electrum_path(), "txcache")
+        if not os.path.exists(self._cache_path):
+            os.makedirs(self._cache_path)
+
+    def _is_persisted(self, tx_id: str) -> bool:
+        txcache_path = os.path.join(self._cache_path, tx_id)
+        return os.path.exists(txcache_path)
+
+    def keys(self):
+        return self._keys
+
+    def items(self):
+        raise NotImplementedError
+
+    def get(self, tx_id: str, default: Any=None) -> Transaction:
+        if tx_id in self._keys:
+            return self[tx_id]
+        return default
+
+    def __iter__(self):
+        return iter(self._keys)
+
+    def __contains__(self, tx_id: str) -> bool:
+        assert len(tx_id) == 32*2
+        if tx_id in self._cache:
+            return True
+        return tx_id in self._keys
+
+    def __len__(self):
+        return len(self._keys)
+
+    def __getitem__(self, tx_id: str) -> Transaction:
+        assert len(tx_id) == 32*2
+        if tx_id not in self._cache:
+            txcache_path = os.path.join(self._cache_path, tx_id)
+            if not os.path.exists(txcache_path):
+                raise KeyError(tx_id)
+
+            with open(txcache_path, "rb") as f:
+                data = f.read()
+                hash_bytes = sha256d(data)
+                if hash_bytes[::-1].hex() != tx_id:
+                    raise Exception("Bad transaction", tx_id)
+                self._cache[tx_id] = Transaction(data.hex())
+        return self._cache[tx_id]
+
+    def __setitem__(self, tx_id: str, tx: Transaction) -> None:
+        assert len(tx_id) == 32*2
+        self._cache[tx_id] = tx
+        self.persist(tx_id, tx)
+
+    def __delitem__(self, tx_id: str) -> None:
+        del self._cache[tx_id]
+        self.unpersist(tx_id)
+
+    def persist(self, tx_id: str, tx: Transaction) -> None:
+        assert len(tx_id) == 32*2
+        if not self._is_persisted(tx_id):
+            txcache_path = os.path.join(self._cache_path, tx_id)
+            with open(txcache_path, "wb") as f:
+                tx_hex = str(tx)
+                f.write(bytes.fromhex(tx_hex))
+
+    def unpersist(self, tx_id: str) -> None:
+        assert len(tx_id) == 32*2
+        txcache_path = os.path.join(self._cache_path, tx_id)
+        os.remove(txcache_path)

--- a/electrumsv/transaction_store.py
+++ b/electrumsv/transaction_store.py
@@ -1,78 +1,123 @@
-import os
-from typing import Any
+import sqlite3
+import threading
+from typing import Optional, Union, Dict, Set, Iterable
 
-from .bitcoin import sha256d
-from .app_state import app_state
+import bitcoinx
+
+from .logs import logs
 from .transaction import Transaction
 
+# TODO: Deletion should be via a flag. Occasional purges might do row deletion of flagged rows.
+# NOTE: We could hash the db and store the hash in the wallet storage to detect changes.
+
 class TransactionStore:
-    def __init__(self, keys) -> None:
-        self._keys = frozenset(keys)
-        self._cache = {}
-        self._cache_path = os.path.join(app_state.config.electrum_path(), "txcache")
-        if not os.path.exists(self._cache_path):
-            os.makedirs(self._cache_path)
+    def __init__(self, wallet_path) -> None:
+        self._logger = logs.get_logger("tx-store")
+        self._state = threading.local()
 
-    def _is_persisted(self, tx_id: str) -> bool:
-        txcache_path = os.path.join(self._cache_path, tx_id)
-        return os.path.exists(txcache_path)
+        self._db_path = wallet_path +".sqlite"
 
-    def keys(self):
-        return self._keys
+        db = self._get_db()
+        self._create(db)
+        self._migrate(db)
+        db.commit()
 
-    def items(self):
-        raise NotImplementedError
+    def _get_db(self):
+        if not hasattr(self._state, "db"):
+            self._state.db = sqlite3.connect(self._db_path)
+        return self._state.db
 
-    def get(self, tx_id: str, default: Any=None) -> Transaction:
-        if tx_id in self._keys:
-            return self[tx_id]
-        return default
+    def _create(self, db):
+        db.execute("CREATE TABLE IF NOT EXISTS Transactions ("+
+                        "Key TEXT, "+
+                        "Value BLOB, "+
+                        "IsPending INTEGER)")
 
-    def __iter__(self):
-        return iter(self._keys)
+    def _migrate(self, db):
+        pass
 
-    def __contains__(self, tx_id: str) -> bool:
-        assert len(tx_id) == 32*2
-        if tx_id in self._cache:
-            return True
-        return tx_id in self._keys
+    def close(self):
+        # TODO: This only closes the database instance held on the current thread. In theory
+        # only the async code behind the daemon should be touching this, not the GUI thread
+        # via the wallet.
+        self._state.db.close()
+        self._state = None
 
-    def __len__(self):
-        return len(self._keys)
+    def has(self, tx_id: str) -> bool:
+        db = self._get_db()
+        cursor = db.execute("SELECT EXISTS(SELECT 1 FROM Transactions WHERE Key=?)", [tx_id])
+        row = cursor.fetchone()
+        return row[0] == 1
 
-    def __getitem__(self, tx_id: str) -> Transaction:
-        assert len(tx_id) == 32*2
-        if tx_id not in self._cache:
-            txcache_path = os.path.join(self._cache_path, tx_id)
-            if not os.path.exists(txcache_path):
-                raise KeyError(tx_id)
+    def add(self, tx_id: str, value: Union[str, Transaction, bytes],
+            is_pending: Optional[bool]=False) -> None:
+        if type(value) is Transaction:
+            value = str(value)
+        if type(value) is str:
+            value = bytes.fromhex(value)
+        assert type(value) is bytes
+        db = self._get_db()
+        db.execute("INSERT INTO Transactions (Key, Value, IsPending) VALUES (?, ?, ?)",
+            [tx_id, value, is_pending])
+        db.commit()
+        self._logger.debug("added %d transaction '%s'", 1, tx_id)
 
-            with open(txcache_path, "rb") as f:
-                data = f.read()
-                hash_bytes = sha256d(data)
-                if hash_bytes[::-1].hex() != tx_id:
-                    raise Exception("Bad transaction", tx_id)
-                self._cache[tx_id] = Transaction(data.hex())
-        return self._cache[tx_id]
+    def add_many(self, map: Dict[str, str], is_pending: Optional[bool]=False) -> None:
+        db = self._get_db()
+        for tx_id, tx_hex in map.items():
+            tx_bytes = bytes.fromhex(tx_hex)
+            db.execute("INSERT INTO Transactions (Key, Value, IsPending) VALUES (?, ?, ?)",
+                [tx_id, tx_bytes, is_pending])
+        db.commit()
+        self._logger.debug("added %d transactions", len(map))
 
-    def __setitem__(self, tx_id: str, tx: Transaction) -> None:
-        assert len(tx_id) == 32*2
-        self._cache[tx_id] = tx
-        self.persist(tx_id, tx)
+    def delete(self, tx_id: str) -> None:
+        db = self._get_db()
+        db.execute("DELETE FROM Transactions WHERE Key=?", [tx_id])
+        db.commit()
+        self._logger.debug("deleted %d transaction '%s'", 1, tx_id)
 
-    def __delitem__(self, tx_id: str) -> None:
-        del self._cache[tx_id]
-        self.unpersist(tx_id)
+    def delete_many(self, tx_ids: Iterable[str]) -> None:
+        db = self._get_db()
+        for tx_id in tx_ids:
+            db.execute("DELETE FROM Transactions WHERE Key=?", [tx_id])
+        db.commit()
+        self._logger.debug("deleted %d transactions", len(tx_ids))
 
-    def persist(self, tx_id: str, tx: Transaction) -> None:
-        assert len(tx_id) == 32*2
-        if not self._is_persisted(tx_id):
-            txcache_path = os.path.join(self._cache_path, tx_id)
-            with open(txcache_path, "wb") as f:
-                tx_hex = str(tx)
-                f.write(bytes.fromhex(tx_hex))
+    def was_received(self, tx_id: str) -> bool:
+        db = self._get_db()
+        cursor = db.execute("SELECT EXISTS("+
+            "SELECT 1 FROM Transactions WHERE IsPending=0 AND Key=?)", [tx_id])
+        row = cursor.fetchone()
+        return row[0] == 1
 
-    def unpersist(self, tx_id: str) -> None:
-        assert len(tx_id) == 32*2
-        txcache_path = os.path.join(self._cache_path, tx_id)
-        os.remove(txcache_path)
+    def get(self, tx_id: str, is_pending: Optional[bool]=None) -> Optional[Transaction]:
+        db = self._get_db()
+        if is_pending is None:
+            cursor = db.execute("SELECT Value FROM Transactions WHERE Key=?", [tx_id])
+        else:
+            cursor = db.execute("SELECT Value FROM Transactions WHERE Key=? AND IsPending=?",
+                [tx_id, is_pending])
+        row = cursor.fetchone()
+        if row is not None:
+            hash_bytes = bitcoinx.double_sha256(row[0])
+            if bitcoinx.hash_to_hex_str(hash_bytes) == tx_id:
+                return Transaction(row[0].hex())
+            self._logger.debug("found transaction with hash mismatch '%s'", tx_id)
+            self.delete(tx_id)
+        return None
+
+    def get_ids(self, is_pending: Optional[bool]=None) -> Set[str]:
+        db = self._get_db()
+        if is_pending is None:
+            cursor = db.execute("SELECT Key FROM Transactions")
+        else:
+            cursor = db.execute("SELECT Key FROM Transactions WHERE IsPending=?",
+                [is_pending])
+        return set(t[0] for t in cursor.fetchall())
+
+    def get_received_ids(self) -> Set[str]:
+        return self.get_ids(is_pending=False)
+
+    def get_pending_ids(self) -> Set[str]:
+        return self.get_ids(is_pending=True)

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -303,7 +303,9 @@ class Abstract_Wallet:
         self.pruned_txo = self.storage.get('pruned_txo', {})
         tx_list = self.storage.get('transactions', {})
         self.tx_store = TransactionStore(self.storage.path)
-        if len(tx_list):
+        # It is possible for the old transactions to still be stored in the encrypted wallet
+        # storage if something happened and the software did not exit cleanly.
+        if len(tx_list) and self.tx_store.count() == 0:
             self.tx_store.add_many(tx_list)
         self.storage.put('transactions', {})
 

--- a/examples/applications/esv_fileupload/rpc.py
+++ b/examples/applications/esv_fileupload/rpc.py
@@ -145,7 +145,7 @@ class LocalRPCFunctions:
     def get_transaction_state(self, tx_id: Optional[str]=None,
             wallet_name: Optional[str]=None) -> bool:
         wallet = self._get_wallet(wallet_name)
-        if tx_id not in wallet.transactions:
+        if not wallet.has_received_transaction(tx_id):
             return None
         height, conf, timestamp = wallet.get_tx_height(tx_id)
         return height, conf, timestamp


### PR DESCRIPTION
This takes a 3.2 MB wallet down to 9 KB and loading time from a minute to instant. There are security concerns with people being able to see your transactions, and also an inability to know what in the cache is or is not still being used.  The security concerns could be alleviated by making the cache per wallet and both deterministically changing the filename and doing per transaction file encryption.

I think this problem has to be solved in the short term, so if you have preferences for how it is solved then please let me know and I will make appropriate changes.