### PR TITLE
Update README.rst - correct pip3 commands for installation on linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,13 +31,13 @@ directory, without installing it on your system.
 
 To run ElectrumSV from its top-level directory, first install the core dependencies::
 
-    pip3 --user -r contrib/requirements/requirements.txt
-    pip3 --user -r contrib/requirements/requirements-binaries.txt
+    pip3 install --user -r contrib/requirements/requirements.txt
+    pip3 install --user -r contrib/requirements/requirements-binaries.txt
 
 If you have a hardware wallet, or want to ensure that the hardware wallet support can work,
 install their specific dependencies::
 
-    pip3 --user -r contrib/requirements/requirements-hw.txt
+    pip3 install --user -r contrib/requirements/requirements-hw.txt
 
 Then invoke it as so::
 
@@ -50,7 +50,7 @@ make the `electrum-sv` command accessible for use.
 
 In order to do so, run these commands::
 
-    pip3 --user -r contrib/requirements/requirements-binaries.txt
+    pip3 install --user -r contrib/requirements/requirements-binaries.txt
     pip3 install .
 
 Getting started on Windows


### PR DESCRIPTION
corrected (?) pip3 command for installation on linux. the command as is produced an error msg on my system, with the corrections all worked fine. Probably the same for Windows, but cannot check.