### PR TITLE
If string is None return None to avoid len(None) exception

### DIFF
--- a/electrumsv/address.py
+++ b/electrumsv/address.py
@@ -178,6 +178,9 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     @classmethod
     def from_string(cls, string, net=Net):
         '''Construct from an address string.'''
+        if string is None:
+            return None
+
         if len(string) > 35:
             try:
                 return cls.from_cashaddr_string(string)

--- a/electrumsv/address.py
+++ b/electrumsv/address.py
@@ -178,9 +178,6 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     @classmethod
     def from_string(cls, string, net=Net):
         '''Construct from an address string.'''
-        if string is None:
-            return None
-
         if len(string) > 35:
             try:
                 return cls.from_cashaddr_string(string)

--- a/electrumsv/commands.py
+++ b/electrumsv/commands.py
@@ -458,7 +458,8 @@ class Commands:
     def _mktx(self, outputs, fee=None, change_addr=None, domain=None, nocheck=False,
               unsigned=False, password=None, locktime=None):
         self.nocheck = nocheck
-        change_addr = Address.from_string(change_addr)
+        if change_addr is not None:
+            change_addr = Address.from_string(change_addr)
         domain = None if domain is None else [Address.from_string(x) for x in domain]
         final_outputs = []
         for address, amount in outputs:


### PR DESCRIPTION
When calling ```paytomany``` via RPC, we are sending a list of outputs and expecting ElectrumSV to choose the appropriate addesses to use.  In this branch, the ```_resolve()``` was changed to a new method ```Address.from_string()``` which is not checking for an empty string and fails on the ```len(string)``` as string = None.