### PR TITLE
replace BTC text with BSV

### DIFF
--- a/electrumsv/commands.py
+++ b/electrumsv/commands.py
@@ -561,7 +561,7 @@ class Commands:
             PR_EXPIRED: 'Expired',
         }
         out['address'] = out.get('address').to_string()
-        out['amount (BTC)'] = format_satoshis(out.get('amount'))
+        out['amount (BSV)'] = format_satoshis(out.get('amount'))
         out['status'] = pr_str[out.get('status', PR_UNKNOWN)]
         return out
 
@@ -684,8 +684,8 @@ param_descriptions = {
     'pubkey': 'Public key',
     'message': 'Clear text message. Use quotes if it contains spaces.',
     'encrypted': 'Encrypted message',
-    'amount': 'Amount to be sent (in BTC). Type \'!\' to send the maximum available.',
-    'requested_amount': 'Requested amount (in BTC).',
+    'amount': 'Amount to be sent (in BSV). Type \'!\' to send the maximum available.',
+    'requested_amount': 'Requested amount (in BSV).',
     'outputs': 'list of ["address", amount]',
     'redeem_script': 'redeem script (hexadecimal)',
 }
@@ -702,7 +702,7 @@ command_options = {
     'labels':      ("-l", "Show the labels of listed addresses"),
     'nocheck':     (None, "Do not verify aliases"),
     'imax':        (None, "Maximum number of inputs"),
-    'fee':         ("-f", "Transaction fee (in BTC)"),
+    'fee':         ("-f", "Transaction fee (in BSV)"),
     'from_addr':   ("-F", "Source address (must be a wallet address; "
                     "use sweep to spend from non-wallet address)."),
     'change_addr': ("-c", "Change address. Default is a spare address, or the source "


### PR DESCRIPTION
Just was noticing when using the addrequest command, there was text in the response with "BTC"...  Figured this should be adjusted on the master branch for future releases.