### PR TITLE
Add utxo cache

### DIFF
--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -586,6 +586,8 @@ class AddressList(QTableView):
             else:
                 self._logger.error("_on_update_check action %s not applied", action)
 
+        self.resizeRowsToContents()
+
     def _on_addresses_created(self, addresses: Iterable[Address], is_change: bool=False) -> None:
         flags = EventFlags.ADDRESS_ADDED
         if is_change:
@@ -614,8 +616,6 @@ class AddressList(QTableView):
         receiving_addresses = self._wallet.get_receiving_addresses()[:]
         change_addresses = self._wallet.get_change_addresses()[:]
 
-        was_empty = len(self._data) == 0
-
         for address in addresses:
             # See if we already know if it is change or receiving.
             event_flags = state[address] & EventFlags.TYPE_MASK
@@ -633,11 +633,6 @@ class AddressList(QTableView):
                     is_change = False
                     n = receiving_addresses.index(address)
             self._base_model.add_line(self._create_address_entry(address, is_change, n=n))
-
-        # If the table was empty, it is possible that the rows have not been resized to contents
-        # yet, because there were no contents. So detect and apply the resize.
-        if was_empty:
-            self.resizeRowsToContents()
 
     def _update_addresses(self, addresses: List[Address], state: Dict[Address, EventFlags]) -> None:
         self._logger.debug("_update_addresses %d", len(addresses))

--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -657,8 +657,9 @@ class AddressList(QTableView):
 
         matches = self._match_addresses(addresses)
         if len(matches) != len(addresses):
+            matched_addresses = [ line.address for (row, line) in matches ]
             self._logger.debug("_update_addresses missing entries %s",
-                [ a.to_string(coin=Net.COIN) for a in matches if a not in addresses ])
+                [ a.to_string(coin=Net.COIN) for a in addresses if a not in matched_addresses ])
         for row, line in matches:
             new_line = self._create_address_entry(line.address,
                 (line.flags & AddressFlags.CHANGE) == AddressFlags.CHANGE,
@@ -675,8 +676,9 @@ class AddressList(QTableView):
         #     [ a.to_string(coin=Net.COIN) for a in addresses ])
         matches = self._match_addresses(addresses)
         if len(matches) != len(addresses):
+            matched_addresses = [ line.address for (row, line) in matches ]
             self._logger.debug("_remove_addresses missing entries %s",
-                [ a.to_string(coin=Net.COIN) for a in matches if a not in addresses ])
+                [ a.to_string(coin=Net.COIN) for a in addresses if a not in matched_addresses ])
         # Make sure that we will be removing rows from the last to the first, to preserve offsets.
         for row, line in sorted(matches, reverse=True, key=lambda v: v[0]):
             self._base_model.remove_row(row)

--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -588,7 +588,11 @@ class AddressList(QTableView):
 
         self.resizeRowsToContents()
 
-    def _on_addresses_created(self, addresses: Iterable[Address], is_change: bool=False) -> None:
+    def _on_addresses_created(self, wallet: Abstract_Wallet, addresses: Iterable[Address],
+            is_change: bool=False) -> None:
+        if wallet is not self._wallet:
+            return
+
         flags = EventFlags.ADDRESS_ADDED
         if is_change:
             flags |= EventFlags.ADDRESS_CHANGE
@@ -601,7 +605,7 @@ class AddressList(QTableView):
     # - Archived.
     # - Usages.
     # - Balance.
-    def _on_addresses_updated(self, addresses: Iterable[Address]) -> None:
+    def _on_addresses_updated(self, wallet: Abstract_Wallet, addresses: Iterable[Address]) -> None:
         new_flags = EventFlags.ADDRESS_UPDATED
         for address in addresses:
             flags = self._pending_state.get(address, EventFlags.UNSET)

--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -613,8 +613,6 @@ class AddressList(QTableView):
 
     def _add_addresses(self, addresses: List[Address], state: Dict[Address, EventFlags]) -> None:
         self._logger.debug("_add_addresses %d", len(addresses))
-        # self._logger.debug("_add_addresses %s",
-        #     [ a.to_string(coin=Net.COIN) for a in addresses ])
 
         # TODO: Use state to identify if we know the receiving or change status of an address.
         receiving_addresses = self._wallet.get_receiving_addresses()[:]
@@ -640,8 +638,6 @@ class AddressList(QTableView):
 
     def _update_addresses(self, addresses: List[Address], state: Dict[Address, EventFlags]) -> None:
         self._logger.debug("_update_addresses %d", len(addresses))
-        # self._logger.debug("_update_addresses %s",
-        #     [ a.to_string(coin=Net.COIN) for a in addresses ])
 
         # TODO(rt12): It should be possible to look at the state and see if partial updates
         # are enough.
@@ -663,7 +659,7 @@ class AddressList(QTableView):
         if len(matches) != len(addresses):
             matched_addresses = [ line.address for (row, line) in matches ]
             self._logger.debug("_update_addresses missing entries %s",
-                [ a.to_string(coin=Net.COIN) for a in addresses if a not in matched_addresses ])
+                [ a.to_string() for a in addresses if a not in matched_addresses ])
         for row, line in matches:
             new_line = self._create_address_entry(line.address,
                 (line.flags & AddressFlags.CHANGE) == AddressFlags.CHANGE,
@@ -676,13 +672,11 @@ class AddressList(QTableView):
 
     def _remove_addresses(self, addresses: List[Address]) -> None:
         self._logger.debug("_remove_addresses %d", len(addresses))
-        # self._logger.debug("_remove_addresses %s",
-        #     [ a.to_string(coin=Net.COIN) for a in addresses ])
         matches = self._match_addresses(addresses)
         if len(matches) != len(addresses):
             matched_addresses = [ line.address for (row, line) in matches ]
             self._logger.debug("_remove_addresses missing entries %s",
-                [ a.to_string(coin=Net.COIN) for a in addresses if a not in matched_addresses ])
+                [ a.to_string() for a in addresses if a not in matched_addresses ])
         # Make sure that we will be removing rows from the last to the first, to preserve offsets.
         for row, line in sorted(matches, reverse=True, key=lambda v: v[0]):
             self._base_model.remove_row(row)

--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -62,7 +62,6 @@ from electrumsv.app_state import app_state
 from electrumsv.bitcoin import address_from_string
 from electrumsv.keystore import Hardware_KeyStore
 from electrumsv.logs import logs
-from electrumsv.networks import Net
 from electrumsv.platform import platform
 from electrumsv.util import profiler
 from electrumsv.wallet import Multisig_Wallet, Abstract_Wallet

--- a/electrumsv/gui/qt/address_list.py
+++ b/electrumsv/gui/qt/address_list.py
@@ -606,6 +606,9 @@ class AddressList(QTableView):
     # - Usages.
     # - Balance.
     def _on_addresses_updated(self, wallet: Abstract_Wallet, addresses: Iterable[Address]) -> None:
+        if wallet is not self._wallet:
+            return
+
         new_flags = EventFlags.ADDRESS_UPDATED
         for address in addresses:
             flags = self._pending_state.get(address, EventFlags.UNSET)
@@ -715,6 +718,9 @@ class AddressList(QTableView):
 
     # The user has edited a label either here, or in some other wallet location.
     def update_labels(self, wallet: Abstract_Wallet, updates: Dict[str, str]) -> None:
+        if wallet is not self._wallet:
+            return
+
         with self._update_lock:
             new_flags = EventFlags.ADDRESS_UPDATED | EventFlags.LABEL_UPDATE
 

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -37,7 +37,7 @@ from typing import Iterable, Tuple, Optional
 import weakref
 import webbrowser
 
-from bitcoinx import PublicKey, Script, Address, P2PKH_Address, TxOutput, hash_to_hex_str
+from bitcoinx import PublicKey, Script, Address, P2PKH_Address, TxOutput
 from bitcoinx import OP_RETURN, OP_FALSE # pylint: disable=no-name-in-module
 
 from PyQt5.QtCore import (pyqtSignal, Qt, QSize, QStringListModel, QTimer, QUrl)
@@ -1705,8 +1705,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
                                       f'broadcast for: {result}')
                     self.logger.debug(f'setting transaction to StateDispatched...')
                     #                 f'and removing used utxos from cache...')
-                    wallet.set_transaction_state(tx.txid(), (TxFlags.StateDispatched | TxFlags.HasByteData))
-                    #used_utxo_keys = [(hash_to_hex_str(input.prev_hash), input.prev_idx) for input in tx.inputs]
+                    wallet.set_transaction_state(tx.txid(),
+                                                 (TxFlags.StateDispatched | TxFlags.HasByteData))
+                    #used_utxo_keys = [(hash_to_hex_str(input.prev_hash),
+                    # input.prev_idx) for input in tx.inputs]
                     #wallet._datastore.utxos.remove_utxos_by_key(used_utxo_keys)
                 return result
 

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -103,8 +103,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
     network_signal = pyqtSignal(str, object)
     history_updated_signal = pyqtSignal()
     network_status_signal = pyqtSignal()
-    addresses_updated_signal = pyqtSignal(object)
-    addresses_created_signal = pyqtSignal(object, object)
+    addresses_updated_signal = pyqtSignal(object, object)
+    addresses_created_signal = pyqtSignal(object, object, object)
 
     def __init__(self, parent_wallet: ParentWallet):
         QMainWindow.__init__(self)
@@ -243,14 +243,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
         self.load_wallet()
         self.app.timer.timeout.connect(self.timer_actions)
 
-    def _on_addresses_created(self, event_name: str, addresses: Iterable[Address],
-            is_change: bool=False) -> None:
+    def _on_addresses_created(self, event_name: str, wallet: Abstract_Wallet,
+            addresses: Iterable[Address], is_change: bool=False) -> None:
         # logger.debug("_on_addresses_created %s %s", [a.to_string() for a in addresses], is_change)
-        self.addresses_created_signal.emit(addresses, is_change)
+        self.addresses_created_signal.emit(wallet, addresses, is_change)
 
-    def _on_addresses_updated(self, event_name: str, addresses: Iterable[Address]) -> None:
+    def _on_addresses_updated(self, event_name: str, wallet: Abstract_Wallet,
+            addresses: Iterable[Address]) -> None:
         # logger.debug("_on_addresses_updated %s", [ a.to_string() for a in addresses ])
-        self.addresses_updated_signal.emit(addresses)
+        self.addresses_updated_signal.emit(wallet, addresses)
 
     def _on_history(self, b):
         self.new_fx_history_signal.emit()

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -2002,6 +2002,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
             'network': self.network,
             'util': util,
             'parent_wallet': self.parent_wallet,
+            # For now we'll alias the default wallet as 'wallet'.
+            'wallet': self.parent_wallet.get_default_wallet(),
             'window': self,
         })
 

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -43,8 +43,8 @@ from aiorpcx import (
 )
 from bitcoinx import (
     MissingHeader, IncorrectBits, InsufficientPoW, hex_str_to_hash, hash_to_hex_str,
-    sha256, double_sha256,
-    classify_output_script)
+    sha256, double_sha256
+)
 
 from .app_state import app_state
 from .bitcoin import scripthash_hex

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1133,7 +1133,7 @@ class Network:
                     wallet.add_transaction(tx_hash, tx, TxFlags.StateCleared |
                                            TxFlags.HasByteData)  # Add to TxCache
                     wallet.handle_incoming_payments(tx, tx_hash)  # Add to UTXOCache
-                    wallet.handle_outgoing_payments(tx)  # Cleanup Frozen coins
+                    #wallet.handle_outgoing_payments(tx)  # Cleanup Frozen coins
 
                     self.trigger_callback('new_transaction', tx, wallet)
         return had_timeout

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1131,6 +1131,11 @@ class Network:
                     logger.error(f'fetching transaction {tx_hash}: {e}')
                 else:
                     wallet.add_transaction(tx_hash, tx, TxFlags.StateCleared)
+
+                    # Add new StateCleared coins to utxo cache + remove redundant frozen coins
+                    tx_entry = wallet._datastore.tx.get_entry(tx_hash, mask=TxFlags.StateCleared)
+                    wallet._datastore.utxos.add_from_tx_entry(tx_entry)
+
                     self.trigger_callback('new_transaction', tx, wallet)
         return had_timeout
 

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1130,7 +1130,8 @@ class Network:
                     logger.exception(e)
                     logger.error(f'fetching transaction {tx_hash}: {e}')
                 else:
-                    wallet.add_transaction(tx_hash, tx, TxFlags.StateCleared)  # Add to TxCache
+                    wallet.add_transaction(tx_hash, tx, TxFlags.StateCleared |
+                                           TxFlags.HasByteData)  # Add to TxCache
                     wallet.handle_incoming_payments(tx, tx_hash)  # Add to UTXOCache
                     wallet.handle_outgoing_payments(tx)  # Cleanup Frozen coins
 

--- a/electrumsv/tests/test_storage_upgrade.py
+++ b/electrumsv/tests/test_storage_upgrade.py
@@ -353,6 +353,8 @@ class TestStorageUpgrade(WalletTestCase):
         # Generically check that all parent keystores are in use.
         self.assertEqual(len(parent_wallet._keystores), len(keystore_indexes))
 
+        parent_wallet.stop()
+
     def _load_storage_from_json_string(self, wallet_json, manual_upgrades=True):
         with open(self.wallet_path, "w") as f:
             f.write(wallet_json)

--- a/electrumsv/tests/test_utxo_cache.py
+++ b/electrumsv/tests/test_utxo_cache.py
@@ -1,0 +1,167 @@
+import unittest
+
+import pytest
+from bitcoinx import Address
+from electrumsv.wallet import Standard_Wallet
+from electrumsv.wallet_database import UTXO, UTXOCache, TxXputCache, DBTxOutput
+
+from bitcoinx import Address, Script
+from electrumsv.wallet_database import UTXO
+
+ADDRESSES = [
+    Address.from_string('miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou'),
+    Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
+]
+
+FROZEN_COINS = {('dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2', 1),
+                ('7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8', 0)}
+
+FROZEN_ADDRESSES = {'dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2',
+                    '7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8'}
+
+SPENDABLE_UTXOS = [
+    UTXO(address=Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
+         height=1329528,
+         is_coinbase=False,
+         out_index=0,
+         script_pubkey=Script(b'v\xa9\x14\x84\xb3[1i\xe4+"}+\x9d\x85s!\t\xa1y\xab\xff\x12\x88'
+                              b'\xac'),
+         tx_hash='8aed908726dc878fb7316fc4f11054dbc69b6ac8b206d3fca5a7412d7e9e458d',
+         value=7782292),
+    UTXO(address=Address.from_string('miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou'),
+         height=1329527,
+         is_coinbase=False,
+         out_index=0,
+         script_pubkey=Script(b'v\xa9\x14&\x0c\x95\x8e\x81\xc8o\xe3.\xc3\xd4\x1d7\x1cy\x0e\xed'
+                                b'\x9a\xb4\xf3\x88\xac'),
+         tx_hash='76d5bfabe40ca6cbd315b04aa24b68fdd8179869fd1c3501d5a88a980c61c1bf',
+         value=3000000)
+]
+
+ALL_UTXOS = [UTXO(address=Address.from_string('miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou'),
+                  height=1329527,
+                  is_coinbase=False,
+                  out_index=0,
+                  script_pubkey=Script(b'v\xa9\x14&\x0c\x95\x8e\x81\xc8o\xe3.\xc3\xd4\x1d7\x1cy'
+                                         b'\x0e\xed\x9a\xb4\xf3\x88\xac'),
+                  tx_hash='76d5bfabe40ca6cbd315b04aa24b68fdd8179869fd1c3501d5a88a980c61c1bf',
+                  value=3000000),
+             UTXO(address=Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
+                  height=1329528,
+                  is_coinbase=False,
+                  out_index=0,
+                  script_pubkey=Script(b'v\xa9\x14\x84\xb3[1i\xe4+"}+\x9d\x85s!\t\xa1y\xab\xff'
+                                         b'\x12\x88\xac'),
+                  tx_hash='8aed908726dc878fb7316fc4f11054dbc69b6ac8b206d3fca5a7412d7e9e458d',
+                  value=7782292),
+             UTXO(address=Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
+                  height=1329528,
+                  is_coinbase=False,
+                  out_index=0,
+                  script_pubkey=Script(b'v\xa9\x14\x84\xb3[1i\xe4+"}+\x9d\x85s!\t\xa1y\xab\xff'
+                                         b'\x12\x88\xac'),
+                  tx_hash='7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8',
+                  value=98768),
+             UTXO(address=Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
+                  height=1329529,
+                  is_coinbase=False,
+                  out_index=1,
+                  script_pubkey=Script(b'v\xa9\x14\x84\xb3[1i\xe4+"}+\x9d\x85s!\t\xa1y\xab\xff'
+                                         b'\x12\x88\xac'),
+                  tx_hash='dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2',
+                  value=2000000)]
+
+ALL_TXOUT = {'76d5bfabe40ca6cbd315b04aa24b68fdd8179869fd1c3501d5a88a980c61c1bf':
+     [DBTxOutput(address_string='miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou', out_tx_n=0, amount=3000000, is_coinbase=False)],
+ '7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8':
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0, amount=98768, is_coinbase=False)],
+ '8aed908726dc878fb7316fc4f11054dbc69b6ac8b206d3fca5a7412d7e9e458d':
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0, amount=7782292, is_coinbase=False)],
+ 'dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2':
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=1, amount=2000000, is_coinbase=False)]}
+
+ALL_TXIN = {}
+
+HISTORY = {
+    ADDRESSES[0]: [
+        ['76d5bfabe40ca6cbd315b04aa24b68fdd8179869fd1c3501d5a88a980c61c1bf', 1329527]
+    ],
+    ADDRESSES[1]: [
+        ['8aed908726dc878fb7316fc4f11054dbc69b6ac8b206d3fca5a7412d7e9e458d', 1329528],
+        ['7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8', 1329528],
+        ['dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2', 1329529]
+    ]
+}
+
+class MockTxOutputCache:
+
+    def get_entries(self, txid):
+        return ALL_TXOUT.get(txid)
+
+
+class MockTxInputCache:
+
+    def get_entries(self, txid):
+        return ALL_TXIN.get(txid, [])
+
+
+class MockWalletData:
+    def __init__(self):
+        self.utxos = UTXOCache()
+        self.txout = MockTxOutputCache()
+        self.txin = MockTxInputCache()
+
+
+class MockNetwork:
+
+    def get_local_height(self):
+        return 1329529
+
+    def get_txouts(self):
+        return
+
+
+class MockWallet(Standard_Wallet):
+    def __init__(self) -> None:
+        self._datastore = MockWalletData()
+        self._frozen_coins = FROZEN_COINS
+        self._frozen_addresses = FROZEN_ADDRESSES
+        self.config = {'confirmed_only': False}
+        self.network = MockNetwork()
+        self._history = HISTORY
+
+    def get_receiving_addresses(self):
+        return ADDRESSES
+
+    def get_change_addresses(self):
+        return []
+
+
+class TestUTXOCache(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mockwallet_instance = MockWallet()
+
+    def test_get_utxos(self):
+        coins = self.mockwallet_instance.get_utxos(domain=None, exclude_frozen=False,
+                                                   mature=False, confirmed_only=False)
+        self.assertEqual(ALL_UTXOS, coins)
+
+    def test_get_utxos_cached(self):
+        coins = self.mockwallet_instance.get_utxos_cached(exclude_frozen=False,
+                                                          mature=False, confirmed_only=False)
+        self.assertEqual(ALL_UTXOS, coins)
+
+    def test_get_spendable_coins(self):
+        coins = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
+        coins_repeated = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
+        self.assertCountEqual(SPENDABLE_UTXOS, coins)
+        self.assertEqual(coins, coins_repeated)
+
+    def test_get_spendable_coins_cached(self):
+        coins_cached = self.mockwallet_instance.get_spendable_coins_cached({}, isInvoice=False)
+        coins = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
+        self.assertEqual(coins, list(coins_cached))
+        self.assertEqual(SPENDABLE_UTXOS, coins_cached)
+

--- a/electrumsv/tests/test_utxo_cache.py
+++ b/electrumsv/tests/test_utxo_cache.py
@@ -1,12 +1,7 @@
 import unittest
-
-import pytest
-from bitcoinx import Address
 from electrumsv.wallet import Standard_Wallet
-from electrumsv.wallet_database import UTXO, UTXOCache, TxXputCache, DBTxOutput
-
+from electrumsv.wallet_database import UTXO, UTXOCache, DBTxOutput
 from bitcoinx import Address, Script
-from electrumsv.wallet_database import UTXO
 
 ADDRESSES = [
     Address.from_string('miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou'),
@@ -16,8 +11,7 @@ ADDRESSES = [
 FROZEN_COINS = {('dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2', 1),
                 ('7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8', 0)}
 
-FROZEN_ADDRESSES = {'dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2',
-                    '7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8'}
+FROZEN_ADDRESSES = set({})
 
 SPENDABLE_UTXOS = [
     UTXO(address=Address.from_string('msccMGHunfHANQWXMZragRggHMkJaBWSFr'),
@@ -72,13 +66,17 @@ ALL_UTXOS = [UTXO(address=Address.from_string('miz93i75XiTdnvzkU6sDddvGcCr4ZrCmo
                   value=2000000)]
 
 ALL_TXOUT = {'76d5bfabe40ca6cbd315b04aa24b68fdd8179869fd1c3501d5a88a980c61c1bf':
-     [DBTxOutput(address_string='miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou', out_tx_n=0, amount=3000000, is_coinbase=False)],
+     [DBTxOutput(address_string='miz93i75XiTdnvzkU6sDddvGcCr4ZrCmou', out_tx_n=0,
+                 amount=3000000, is_coinbase=False)],
  '7fb5e74c98957fdcd645b5e42ef959d4a20e8dd7b23a9d911159a0ed4f059bb8':
-     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0, amount=98768, is_coinbase=False)],
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0,
+                 amount=98768, is_coinbase=False)],
  '8aed908726dc878fb7316fc4f11054dbc69b6ac8b206d3fca5a7412d7e9e458d':
-     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0, amount=7782292, is_coinbase=False)],
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=0,
+                 amount=7782292, is_coinbase=False)],
  'dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2':
-     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=1, amount=2000000, is_coinbase=False)]}
+     [DBTxOutput(address_string='msccMGHunfHANQWXMZragRggHMkJaBWSFr', out_tx_n=1,
+                 amount=2000000, is_coinbase=False)]}
 
 ALL_TXIN = {}
 
@@ -92,6 +90,7 @@ HISTORY = {
         ['dde980dd85e34e7ab2ba09f4e3408323c84132fe7ec1ac1fdfb9bd0a953601f2', 1329529]
     ]
 }
+
 
 class MockTxOutputCache:
 
@@ -139,29 +138,71 @@ class MockWallet(Standard_Wallet):
 
 class TestUTXOCache(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.mockwallet_instance = MockWallet()
+    def setUp(self) -> None:
+        self.mockwallet_instance = MockWallet()
 
     def test_get_utxos(self):
         coins = self.mockwallet_instance.get_utxos(domain=None, exclude_frozen=False,
                                                    mature=False, confirmed_only=False)
         self.assertEqual(ALL_UTXOS, coins)
 
+    def test_get_utxos_exclude_frozen(self):
+        coins = self.mockwallet_instance.get_utxos(domain=None, exclude_frozen=True,
+                                                   mature=False, confirmed_only=False)
+        self.assertCountEqual(SPENDABLE_UTXOS, coins)
+
     def test_get_utxos_cached(self):
+        default = self.mockwallet_instance.get_utxos_cached()
         coins = self.mockwallet_instance.get_utxos_cached(exclude_frozen=False,
                                                           mature=False, confirmed_only=False)
+        self.assertEqual(ALL_UTXOS, default)
         self.assertEqual(ALL_UTXOS, coins)
+
+    def test_get_utxos_cached_exclude_frozen(self):
+        coins = self.mockwallet_instance.get_utxos_cached(exclude_frozen=True,
+                                                          mature=False, confirmed_only=False)
+        self.assertCountEqual(SPENDABLE_UTXOS, coins)
 
     def test_get_spendable_coins(self):
         coins = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
-        coins_repeated = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
+        repeat = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
         self.assertCountEqual(SPENDABLE_UTXOS, coins)
-        self.assertEqual(coins, coins_repeated)
+        self.assertEqual(coins, repeat)
 
     def test_get_spendable_coins_cached(self):
         coins_cached = self.mockwallet_instance.get_spendable_coins_cached({}, isInvoice=False)
         coins = self.mockwallet_instance.get_spendable_coins(None, {}, isInvoice=False)
-        self.assertEqual(coins, list(coins_cached))
-        self.assertEqual(SPENDABLE_UTXOS, coins_cached)
 
+        coins_cached_repeat = self.mockwallet_instance.get_spendable_coins_cached({},
+                                                                                  isInvoice=False)
+        self.assertCountEqual(coins, list(coins_cached))
+        self.assertCountEqual(SPENDABLE_UTXOS, list(coins_cached))
+        self.assertEqual(coins_cached, coins_cached_repeat)
+
+    def test_filter_frozen_utxos(self):
+        utxo_cache = UTXOCache(ALL_UTXOS)
+        frozen_utxos = self.mockwallet_instance._datastore.utxos.get_frozen_utxos(
+            FROZEN_COINS, utxo_cache)
+        filtered = self.mockwallet_instance._datastore.utxos.filter_frozen_utxos(frozen_utxos,
+                                                                                 utxo_cache)
+        self.assertCountEqual(SPENDABLE_UTXOS, list(filtered))
+
+    def test_remove_utxos(self):
+        utxo_cache = self.mockwallet_instance.get_utxos_cached(exclude_frozen=False)  # load cache
+        utxos_for_removal = self.mockwallet_instance._datastore.utxos.get_frozen_utxos(
+            FROZEN_COINS, utxo_cache)
+
+        # remove spent or frozen coins from utxo set
+        self.mockwallet_instance._datastore.utxos.remove_utxos(utxos_for_removal)
+
+        self.assertCountEqual(SPENDABLE_UTXOS, self.mockwallet_instance._datastore.utxos)
+
+    def test_undo_remove_utxos(self):
+        """Adds back utxos that have been unfrozen"""
+        self.mockwallet_instance.get_utxos_cached(exclude_frozen=True)  # load cache
+        utxos_to_add_back = self.mockwallet_instance._datastore.utxos.get_frozen_utxos(FROZEN_COINS, ALL_UTXOS)
+
+        # add back coins that were not spent or unfrozen due to failed broadcast
+        self.mockwallet_instance._datastore.utxos.undo_remove_utxos(utxos_to_add_back)
+
+        self.assertCountEqual(ALL_UTXOS, self.mockwallet_instance._datastore.utxos)

--- a/electrumsv/tests/test_wallet.py
+++ b/electrumsv/tests/test_wallet.py
@@ -17,6 +17,7 @@ from electrumsv.storage import (get_categorised_files, multisig_type,
 from electrumsv.transaction import XPublicKey
 from electrumsv.wallet import (sweep_preparations, ImportedPrivkeyWallet, ImportedAddressWallet,
     Multisig_Wallet, ParentWallet, Standard_Wallet, UTXO)
+from electrumsv.wallet_database import DatabaseContext
 
 from .util import setup_async, tear_down_async, TEST_WALLET_PATH
 
@@ -40,6 +41,9 @@ class MockStorage:
 
     def get_path(self) -> str:
         return self.path
+
+    def get_db_context(self):
+        return DatabaseContext(self.path)
 
 
 def setUpModule():

--- a/electrumsv/tests/test_wallet.py
+++ b/electrumsv/tests/test_wallet.py
@@ -15,9 +15,11 @@ from electrumsv.networks import Net, SVMainnet, SVTestnet
 from electrumsv.storage import (get_categorised_files, multisig_type,
     WalletStorage, WalletStorageInfo)
 from electrumsv.transaction import XPublicKey
-from electrumsv.wallet import (sweep_preparations, ImportedPrivkeyWallet, ImportedAddressWallet,
-    Multisig_Wallet, ParentWallet, Standard_Wallet, UTXO)
-from electrumsv.wallet_database import DatabaseContext
+from electrumsv.wallet import (sweep_preparations,
+        ImportedPrivkeyWallet, ImportedAddressWallet,
+        Multisig_Wallet, ParentWallet, Standard_Wallet
+)
+from electrumsv.wallet_database import DatabaseContext, UTXO
 
 from .util import setup_async, tear_down_async, TEST_WALLET_PATH
 

--- a/electrumsv/tests/test_wallet_database.py
+++ b/electrumsv/tests/test_wallet_database.py
@@ -1004,7 +1004,7 @@ class TestTxCache:
 
         # Update.
         metadata_2 = TxData(position=22)
-        cache.update_or_add([
+        updated_ids = cache.update_or_add([
             (tx_id_1, metadata_2, None, TxFlags.HasPosition | TxFlags.StateDispatched) ])
         entry = cache.get_entry(tx_id_1)
         store_flags = self.store.get_flags(tx_id_1)
@@ -1016,6 +1016,7 @@ class TestTxCache:
             f"{TxFlags.to_repr(expected_flags)} !=  {TxFlags.to_repr(entry.flags)}"
         assert bytedata_1 == entry.bytedata
         assert metadata_2.position == entry.metadata.position
+        assert updated_ids == set([ tx_id_1 ])
 
     def test_update_flags(self):
         cache = TxCache(self.store)

--- a/electrumsv/tests/test_wallet_vertical.py
+++ b/electrumsv/tests/test_wallet_vertical.py
@@ -9,6 +9,7 @@ from electrumsv.bitcoin import seed_type, address_from_string
 from electrumsv import keystore
 from electrumsv import storage
 from electrumsv import wallet
+from electrumsv import wallet_database
 
 from .util import setup_async, tear_down_async
 
@@ -37,6 +38,9 @@ class MockStorage:
 
     def get_path(self):
         return self.path
+
+    def get_db_context(self):
+        return wallet_database.DatabaseContext(self.path)
 
 
 class TestWalletKeystoreAddressIntegrity(unittest.TestCase):

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -930,7 +930,7 @@ class Abstract_Wallet:
             self._datastore.txout.add_entries(txouts)
 
         if len(affected_addresses):
-            self.network.trigger_callback('on_addresses_updated', affected_addresses)
+            self.network.trigger_callback('on_addresses_updated', self, affected_addresses)
 
     # Used by ImportedWalletBase
     def _remove_transaction(self, tx_hash: str) -> None:
@@ -1544,7 +1544,9 @@ class Abstract_Wallet:
             self.save_addresses()
             # Ensures addresses show in address list
             if self.network:
-                self.network.trigger_callback('on_addresses_created', addresses, for_change)
+                # There is no unique id for the child wallet, so we just pass the wallet for now.
+                self.network.trigger_callback('on_addresses_created', self, addresses,
+                    for_change)
 
     async def new_addresses(self) -> List[Address]:
         await self._new_addresses_event.wait()

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -811,8 +811,7 @@ class Abstract_Wallet:
 
         # Fast track + exclude_frozen
         if exclude_frozen and mature and not confirmed_only:
-            """if utxos are frozen + consumed from 'left side' of deque, this will still be fast"""
-
+            # if utxos are frozen + consumed from 'left side' of deque, this will still be fast
             frozen_utxos = self._datastore.utxos.get_frozen_utxos(self._frozen_coins, utxos)
             return self._datastore.utxos.filter_frozen_utxos(frozen_utxos, utxos)
 

--- a/electrumsv/wallet_database.py
+++ b/electrumsv/wallet_database.py
@@ -14,11 +14,12 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from io import BytesIO
 import json
+import queue
 import random
 import sqlite3
 import threading
 import time
-from typing import Optional, Dict, Set, Iterable, List, Tuple, Union, Any
+from typing import Optional, Dict, Set, Iterable, List, Tuple, Union, Any, Callable
 
 import bitcoinx
 
@@ -117,49 +118,193 @@ def byte_repr(value):
     return f"ByteData({len(value)})"
 
 
-# TODO: Deletion should be via a flag. Occasional purges might do row deletion of flagged rows.
-# NOTE: We could hash the db and store the hash in the wallet storage to detect changes.
+class WriteDisabledError(Exception):
+    pass
+
+
+WriteCallbackType = Callable[[sqlite3.Connection], None]
+CompletionCallbackType = Callable[[], None]
+
+class SqliteWriteDispatcher:
+    def __init__(self, db_context: "DatabaseContext") -> None:
+        self._db_context = db_context
+        self._logger = logs.get_logger(self.__class__.__name__)
+        self._logger.debug("1")
+
+        self._writer_queue = queue.Queue()
+        self._writer_thread = threading.Thread(target=self._writer_thread_main, daemon=True)
+        self._writer_loop_event = threading.Event()
+        self._callback_queue = queue.Queue()
+        self._callback_thread = threading.Thread(target=self._callback_thread_main, daemon=True)
+        self._callback_loop_event = threading.Event()
+
+        self._allow_puts = True
+        self._is_alive = True
+        self._exit_when_empty = False
+
+        self._writer_thread.start()
+        self._callback_thread.start()
+
+    def _writer_thread_main(self) -> None:
+        self._db = self._db_context.acquire_connection()
+
+        # NOTE(rt12): Do not increase. If a higher batch size hits an integrity error and is rolled
+        # back, we will need to apply the existing `write_callbacks` one by one, and not apply
+        # them all which still requires some special handling as with the existing logic we'll
+        # just reapply the same batch on the next loop.
+        # NOTE(rt12): Before increasing verify that the neither Sqlite or sqlite3 do autocommit
+        # on every statement. This really needs a unit test.
+        maximum_batch_size = 1
+        write_callbacks: List[WriteCallbackType] = []
+        while self._is_alive:
+            self._writer_loop_event.set()
+
+            # Block until we have at least one write action. If we already have write actions at
+            # this point, it is because we need to retry after a transaction was rolled back.
+            if len(write_callbacks) == 0:
+                try:
+                    write_callback: WriteCallbackType = self._writer_queue.get(timeout=0.1)
+                except queue.Empty:
+                    if self._exit_when_empty:
+                        return
+                    continue
+                write_callbacks.append(write_callback)
+
+            # Gather the rest of the batch for this transaction.
+            while len(write_callbacks) < maximum_batch_size and not self._writer_queue.empty():
+                write_callbacks.append(self._writer_queue.get_nowait())
+
+            # Using the connection as a context manager, apply the batch as a transaction.
+            completion_callbacks = []
+            try:
+                with self._db:
+                    for write_callback in write_callbacks:
+                        completion_callback = write_callback(self._db)
+                        if completion_callback is not None:
+                            completion_callbacks.append(completion_callback)
+            except sqlite3.IntegrityError as e:
+                self._logger.exception("Database write failure", exc_info=e)
+                # The transaction was rolled back.
+                if maximum_batch_size > 1:
+                    self._logger.debug("Retrying with batch size of 1")
+                    # We're going to try and reapply the write actions one by one.
+                    maximum_batch_size = 1
+                    continue
+                # We applied the batch actions one by one. If there was an error with this action
+                # then we've logged it, so we can discard it for lack of any other option.
+                write_callbacks.clear()
+                continue
+            else:
+                # The transaction was successfully committed.
+                write_callbacks.clear()
+
+            for completion_callback in completion_callbacks:
+                self._callback_queue.put_nowait(completion_callback)
+
+    def _callback_thread_main(self) -> None:
+        while self._is_alive:
+            self._callback_loop_event.set()
+
+            # A perpetually blocking get will not get interrupted by CTRL+C.
+            try:
+                callback: CompletionCallbackType = self._callback_queue.get(timeout=0.1)
+            except queue.Empty:
+                if self._exit_when_empty:
+                    return
+                continue
+
+            try:
+                callback()
+            except Exception as e:
+                self._logger.exception("Exception within completion callback", exc_info=e)
+
+    def put(self, write_callback: Optional[WriteCallbackType]=None) -> None:
+        # If the writer is closed, then it is expected the caller should have made sure that
+        # no more puts will be made, and the error will only be raised if something puts to
+        # flag that it is wrong.
+        if not self._allow_puts:
+            raise WriteDisabledError()
+
+        self._writer_queue.put_nowait(write_callback)
+
+    def stop(self) -> None:
+        if self._exit_when_empty:
+            return
+
+        self._allow_puts = False
+        self._exit_when_empty = True
+
+        # Wait for both threads to exit.
+        self._writer_loop_event.wait()
+        self._writer_thread.join()
+        self._db_context.release_connection(self._db)
+        self._db = None
+        self._callback_loop_event.wait()
+        self._callback_thread.join()
+
+        self._is_alive = False
+
+    def is_stopped(self) -> bool:
+        return not self._is_alive
+
+
+class DatabaseContext:
+    def __init__(self, wallet_path: str) -> None:
+        if not wallet_path.endswith(DATABASE_EXT):
+            wallet_path += DATABASE_EXT
+        self._db_path = wallet_path
+        self._connections = []
+
+        self._write_dispatcher = SqliteWriteDispatcher(self)
+
+    def acquire_connection(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._connections.append(connection)
+        return connection
+
+    def release_connection(self, connection: sqlite3.Connection) -> None:
+        self._connections.remove(connection)
+        connection.close()
+
+    def queue_write(self, write_callback: WriteCallbackType) -> None:
+        self._write_dispatcher.put(write_callback)
+
+    def close(self) -> None:
+        self._write_dispatcher.stop()
+        assert self.is_closed()
+
+    def is_closed(self) -> bool:
+        return len(self._connections) == 0 and self._write_dispatcher.is_stopped()
+
 
 
 class BaseWalletStore:
     _table_name = None
 
-    def __init__(self, table_name: str, wallet_path: str, aeskey: Optional[bytes], group_id: int,
+    def __init__(self, table_name: str, db_context: DatabaseContext, aeskey: Optional[bytes],
+            group_id: Optional[int]=None,
             migration_context: Optional[MigrationContext]=None) -> None:
         self.set_aeskey(aeskey)
 
         self._group_id = group_id
-        self._dbs: Dict[int, sqlite3.Connection] = {}
-
-        self._db_path = self.get_db_path(wallet_path)
+        self._db_context = db_context
+        self._db = db_context.acquire_connection()
 
         self._set_table_name(table_name)
 
-        db = self._get_db()
+        # These are the sole allowed writes outside of the write dispatcher.
         if migration_context is not None:
-            self._db_migrate(db, migration_context)
+            self._db_migrate(self._db, migration_context)
         else:
-            self._db_create(db)
-        db.commit()
-
-        self._fetch_write_timestamp()
+            self._db_create(self._db)
+        self._db.commit()
 
     def close(self):
         if self._aes_key is None:
             del self._decrypt
             del self._encrypt
-
-    @staticmethod
-    def get_db_path(wallet_path: str) -> str:
-        if not wallet_path.endswith(DATABASE_EXT):
-            wallet_path += DATABASE_EXT
-        return wallet_path
-
-    def _get_db(self) -> sqlite3.Connection:
-        thread_id = threading.get_ident()
-        if thread_id not in self._dbs:
-            self._dbs[thread_id] = sqlite3.connect(self._db_path)
-        return self._dbs[thread_id]
+        self._db_context.release_connection(self._db)
+        self._db = None
 
     def set_aeskey(self, aeskey: Optional[bytes]) -> None:
         if aeskey is None:
@@ -191,35 +336,9 @@ class BaseWalletStore:
             column_types[column_name] = column_type
         return column_types
 
-    def get_write_timestamp(self):
-        "Get the cached write timestamp (when anything was last updated or deleted)."
-        return self._write_timestamp
-
     def _get_current_timestamp(self):
         "Get the current timestamp in a form suitable for database column storage."
         return int(time.time())
-
-    def _fetch_write_timestamp(self):
-        "Calculate the timestamp of the last write to this table, based on database metadata."
-        self._write_timestamp = 0
-
-        if self._table_name is None:
-            return
-
-        db = self._get_db()
-        cursor = db.execute(f"SELECT DateUpdated FROM {self._table_name} "+
-            "WHERE GroupId=? "+
-            "ORDER BY DateUpdated DESC LIMIT 1", [self._group_id])
-        row = cursor.fetchone()
-        if row is not None:
-            self._write_timestamp = max(row[0], self._write_timestamp)
-
-        cursor = db.execute(f"SELECT DateDeleted FROM {self._table_name} "+
-            "WHERE GroupId=? "+
-            "ORDER BY DateDeleted DESC LIMIT 1", [self._group_id])
-        row = cursor.fetchone()
-        if row is not None and row[0] is not None:
-            self._write_timestamp = max(row[0], self._write_timestamp)
 
     def _encrypt_nop(self, value: bytes) -> bytes:
         return value
@@ -237,9 +356,8 @@ class BaseWalletStore:
         return self._decrypt(value).hex()
 
     def execute_unsafe(self, query: str, *params: Iterable[Any]) -> Any:
-        db = self._get_db()
-        db.execute(query, params)
-        db.commit()
+        self._db.execute(query, params)
+        self._db.commit()
 
 
 class StringKeyMixin:
@@ -270,11 +388,11 @@ class EncryptedKeyMixin:
 
 
 class GenericKeyValueStore(BaseWalletStore):
-    def __init__(self, table_name: str, wallet_path: str, aeskey: Optional[bytes],
+    def __init__(self, table_name: str, db_context: DatabaseContext, aeskey: Optional[bytes],
             group_id: int, migration_context: Optional[MigrationContext]=None) -> None:
         self._logger = logs.get_logger(f"{table_name}-store")
 
-        super().__init__(table_name, wallet_path, aeskey, group_id, migration_context)
+        super().__init__(table_name, db_context, aeskey, group_id, migration_context)
 
     def has_unique_keys(self) -> bool:
         return True
@@ -333,25 +451,6 @@ class GenericKeyValueStore(BaseWalletStore):
         else:
             raise Exception("Asked to migrate unexpected versions", context)
 
-    def _fetch_write_timestamp(self):
-        "Calculate the timestamp of the last write to this table, based on database metadata."
-        self._write_timestamp = 0
-
-        db = self._get_db()
-        cursor = db.execute(f"SELECT DateUpdated FROM {self._table_name} "+
-            "WHERE GroupId=? "+
-            "ORDER BY DateUpdated DESC LIMIT 1", [self._group_id])
-        row = cursor.fetchone()
-        if row is not None:
-            self._write_timestamp = max(row[0], self._write_timestamp)
-
-        cursor = db.execute(f"SELECT DateDeleted FROM {self._table_name} "+
-            "WHERE GroupID=? "+
-            "ORDER BY DateDeleted DESC LIMIT 1", [self._group_id])
-        row = cursor.fetchone()
-        if row is not None and row[0] is not None:
-            self._write_timestamp = max(row[0], self._write_timestamp)
-
     @tprofiler
     def add(self, key: str, value: bytes) -> None:
         return self._add(key, value)
@@ -361,10 +460,8 @@ class GenericKeyValueStore(BaseWalletStore):
         ekey = self._encrypt_key(key)
         evalue = self._encrypt(value)
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.execute(self._CREATE_SQL, [self._group_id, ekey, evalue, timestamp, timestamp])
-        db.commit()
+        self._db.execute(self._CREATE_SQL, [self._group_id, ekey, evalue, timestamp, timestamp])
+        self._db.commit()
         self._logger.debug("add '%s'", key)
 
     @tprofiler
@@ -375,17 +472,14 @@ class GenericKeyValueStore(BaseWalletStore):
             assert type(value) is bytes, f"bad value {value}"
             datas.append([ self._group_id, self._encrypt_key(key), self._encrypt(value),
                 timestamp, timestamp])
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.executemany(self._CREATE_SQL, datas)
-        db.commit()
+        self._db.executemany(self._CREATE_SQL, datas)
+        self._db.commit()
         self._logger.debug("add_many '%s'", list(t[0] for t in entries))
 
     @tprofiler
     def get_value(self, key: str) -> Optional[bytes]:
         ekey = self._encrypt_key(key)
-        db = self._get_db()
-        cursor = db.execute(self._READ_SQL, [self._group_id, ekey])
+        cursor = self._db.execute(self._READ_SQL, [self._group_id, ekey])
         row = cursor.fetchone()
         if row is not None:
             return self._decrypt(row[0])
@@ -393,7 +487,6 @@ class GenericKeyValueStore(BaseWalletStore):
 
     @tprofiler
     def get_many_values(self, keys: Iterable[str]) -> List[Tuple[str, bytes]]:
-        db = self._get_db()
         query = self._READ_ALL_SQL
         params = [ self._group_id ]
 
@@ -412,7 +505,7 @@ class GenericKeyValueStore(BaseWalletStore):
             batch_ekeys = ekeys[:batch_size]
             batch_query = (query +
                 " AND Key IN ({0})".format(",".join("?" for k in batch_ekeys)))
-            cursor = db.execute(batch_query, params + batch_ekeys)
+            cursor = self._db.execute(batch_query, params + batch_ekeys)
             _collect_results(cursor, results)
             ekeys = ekeys[batch_size:]
 
@@ -420,22 +513,19 @@ class GenericKeyValueStore(BaseWalletStore):
 
     @tprofiler
     def get_all(self) -> Optional[bytes]:
-        db = self._get_db()
-        cursor = db.execute(self._READ_ALL_SQL, [ self._group_id ])
+        cursor = self._db.execute(self._READ_ALL_SQL, [ self._group_id ])
         return [ (self._decrypt_key(row[0]), self._decrypt(row[1])) for row in cursor.fetchall() ]
 
     @tprofiler
     def get_values(self, key: str) -> List[bytes]:
         ekey = self._encrypt_key(key)
-        db = self._get_db()
-        cursor = db.execute(self._READ_SQL, [self._group_id, ekey])
+        cursor = self._db.execute(self._READ_SQL, [self._group_id, ekey])
         return [ self._decrypt(row[0]) for row in cursor.fetchall() ]
 
     @tprofiler
     def get_row(self, key: str) -> Optional[Tuple[bytes, int, int, int]]:
         ekey = self._encrypt_key(key)
-        db = self._get_db()
-        cursor = db.execute(self._READ_ROW_SQL, [self._group_id, ekey])
+        cursor = self._db.execute(self._READ_ROW_SQL, [self._group_id, ekey])
         row = cursor.fetchone()
         if row is not None:
             return (self._decrypt(row[0]), row[1], row[2], row[3])
@@ -453,10 +543,8 @@ class GenericKeyValueStore(BaseWalletStore):
             ekey = self._encrypt_key(key)
             evalue = self._encrypt(value)
             timestamp = self._get_current_timestamp()
-            self._write_timestamp = timestamp
-            db = self._get_db()
-            db.execute(self._UPSERT_SQL, [self._group_id, ekey, evalue, timestamp, timestamp])
-            db.commit()
+            self._db.execute(self._UPSERT_SQL, [self._group_id, ekey, evalue, timestamp, timestamp])
+            self._db.commit()
             self._logger.debug("upsert '%s'", key)
         else:
             assert self.has_unique_keys()
@@ -472,11 +560,9 @@ class GenericKeyValueStore(BaseWalletStore):
         ekey = self._encrypt_key(key)
         evalue = self._encrypt(value)
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        cursor = db.execute(self._UPDATE_SQL, [evalue, timestamp, self._group_id, ekey])
+        cursor = self._db.execute(self._UPDATE_SQL, [evalue, timestamp, self._group_id, ekey])
         update_count = cursor.rowcount
-        db.commit()
+        self._db.commit()
         self._logger.debug("updated '%s' for %d rows", key, update_count)
         return update_count
 
@@ -488,20 +574,16 @@ class GenericKeyValueStore(BaseWalletStore):
             assert type(value) is bytes
             datas.append(
                 [ self._encrypt(value), timestamp, self._group_id, self._encrypt_key(key) ])
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.executemany(self._UPDATE_SQL, datas)
-        db.commit()
+        self._db.executemany(self._UPDATE_SQL, datas)
+        self._db.commit()
         self._logger.debug("update_many '%s'", list(t[0] for t in entries))
 
     @tprofiler
     def delete(self, key: str) -> None:
         ekey = self._encrypt_key(key)
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.execute(self._DELETE_SQL, [timestamp, self._group_id, ekey])
-        db.commit()
+        self._db.execute(self._DELETE_SQL, [timestamp, self._group_id, ekey])
+        self._db.commit()
         self._logger.debug("deleted '%s'", key)
 
     @tprofiler
@@ -509,10 +591,8 @@ class GenericKeyValueStore(BaseWalletStore):
         ekey = self._encrypt_key(key)
         evalue = self._encrypt(value)
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.execute(self._DELETE_VALUE_SQL, [timestamp, self._group_id, ekey, evalue])
-        db.commit()
+        self._db.execute(self._DELETE_VALUE_SQL, [timestamp, self._group_id, ekey, evalue])
+        self._db.commit()
         self._logger.debug("deleted value for '%s'", key)
 
     @tprofiler
@@ -523,10 +603,8 @@ class GenericKeyValueStore(BaseWalletStore):
             ekey = self._encrypt_key(key)
             evalue = self._encrypt(value)
             datas.append((timestamp, self._group_id, ekey, evalue))
-        self._write_timestamp = timestamp
-        db = self._get_db()
-        db.executemany(self._DELETE_VALUE_SQL, datas)
-        db.commit()
+        self._db.executemany(self._DELETE_VALUE_SQL, datas)
+        self._db.commit()
         self._logger.debug("deleted values for '%s'", [ v[0] for v in entries ])
 
     def _delete_duplicates(self) -> None:
@@ -633,9 +711,9 @@ class DBTxInput(namedtuple("DBTxInputTuple", "address_string prevout_tx_hash pre
 
 class TransactionInputStore(HexKeyMixin, EncryptedKeyMixin, GenericKeyValueStore,
         AbstractTransactionXput):
-    def __init__(self, wallet_path: str, aeskey: Optional[bytes],
+    def __init__(self, db_context: DatabaseContext, aeskey: Optional[bytes],
             group_id: int, migration_context: Optional[MigrationContext]=None) -> None:
-        super().__init__("TransactionInputs", wallet_path, aeskey, group_id, migration_context)
+        super().__init__("TransactionInputs", db_context, aeskey, group_id, migration_context)
 
     def has_unique_keys(self) -> bool:
         return False
@@ -687,9 +765,9 @@ class DBTxOutput(namedtuple("DBTxOutputTuple", "address_string out_tx_n amount i
 
 class TransactionOutputStore(HexKeyMixin, EncryptedKeyMixin, GenericKeyValueStore,
         AbstractTransactionXput):
-    def __init__(self, wallet_path: str, aeskey: Optional[bytes],
+    def __init__(self, db_context: DatabaseContext, aeskey: Optional[bytes],
             group_id: int, migration_context: Optional[MigrationContext]=None) -> None:
-        super().__init__("TransactionOutputs", wallet_path, aeskey, group_id, migration_context)
+        super().__init__("TransactionOutputs", db_context, aeskey, group_id, migration_context)
 
     def has_unique_keys(self) -> bool:
         return False
@@ -764,11 +842,11 @@ class TransactionStore(BaseWalletStore):
     outputs.
     """
 
-    def __init__(self, wallet_path: str, aeskey: Optional[bytes], group_id: int,
+    def __init__(self, db_context: DatabaseContext, aeskey: Optional[bytes], group_id: int,
             migration_context: Optional[MigrationContext]=None) -> None:
         self._logger = logs.get_logger("tx-store")
 
-        super().__init__("Transactions", wallet_path, aeskey, group_id, migration_context)
+        super().__init__("Transactions", db_context, aeskey, group_id, migration_context)
 
     def _db_create(self, db) -> None:
         db.execute(
@@ -878,8 +956,7 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def has(self, tx_id: str) -> bool:
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
-        cursor = db.execute("SELECT EXISTS(SELECT 1 FROM Transactions "+
+        cursor = self._db.execute("SELECT EXISTS(SELECT 1 FROM Transactions "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL)", [self._group_id, etx_id])
         row = cursor.fetchone()
         return row[0] == 1
@@ -887,8 +964,7 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def get_flags(self, tx_id: str) -> Optional[int]:
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
-        cursor = db.execute(
+        cursor = self._db.execute(
             "SELECT Flags FROM Transactions "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL", [self._group_id, etx_id])
         row = cursor.fetchone()
@@ -898,13 +974,12 @@ class TransactionStore(BaseWalletStore):
     def get(self, tx_id: str, flags: Optional[int]=None,
             mask: Optional[int]=None) -> Optional[Tuple[TxData, Optional[bytes], int]]:
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
         clause, params = self._flag_clause(flags, mask)
         query = ("SELECT MetaData, ByteData, Flags FROM Transactions "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL")
         if clause:
             query += " AND "+ clause
-        cursor = db.execute(query, [self._group_id, etx_id] + params)
+        cursor = self._db.execute(query, [self._group_id, etx_id] + params)
         row = cursor.fetchone()
         if row is not None:
             bytedata = self._decrypt(row[1]) if row[1] is not None else None
@@ -914,7 +989,6 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def get_many(self, flags: Optional[int]=None, mask: Optional[int]=None,
             tx_ids: Optional[Iterable[str]]=None) -> List[Tuple[str, TxData, Optional[bytes], int]]:
-        db = self._get_db()
         query = ("SELECT Key, MetaData, ByteData, Flags FROM Transactions "+
             "WHERE GroupId=? AND DateDeleted IS NULL")
         params = [ self._group_id ]
@@ -941,11 +1015,11 @@ class TransactionStore(BaseWalletStore):
                 batch_etx_ids = etx_ids[:batch_size]
                 batch_query = (query +
                     " AND Key IN ({0})".format(",".join("?" for k in batch_etx_ids)))
-                cursor = db.execute(batch_query, params + batch_etx_ids)
+                cursor = self._db.execute(batch_query, params + batch_etx_ids)
                 _collect_results(cursor, results)
                 etx_ids = etx_ids[batch_size:]
         else:
-            cursor = db.execute(query, params)
+            cursor = self._db.execute(query, params)
             _collect_results(cursor, results)
         return results
 
@@ -953,13 +1027,12 @@ class TransactionStore(BaseWalletStore):
     def get_metadata(self, tx_id: str, flags: Optional[int]=None,
             mask: Optional[int]=None) -> Optional[Tuple[TxData, int]]:
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
         clause, params = self._flag_clause(flags, mask)
         query = ("SELECT MetaData, Flags FROM Transactions "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL")
         if clause:
             query += " AND "+ clause
-        cursor = db.execute(query, [self._group_id, etx_id] + params)
+        cursor = self._db.execute(query, [self._group_id, etx_id] + params)
         row = cursor.fetchone()
         if row is not None:
             return self._unpack_data(self._decrypt(row[0]), row[1]), row[1]
@@ -968,7 +1041,6 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def get_metadata_many(self, flags: Optional[int]=None, mask: Optional[int]=None,
             tx_ids: Optional[Iterable[str]]=None) -> List[Tuple[str, TxData, int]]:
-        db = self._get_db()
         query = ("SELECT Key, MetaData, Flags FROM Transactions "+
             "WHERE GroupId=? AND DateDeleted IS NULL")
         params = [ self._group_id ]
@@ -995,19 +1067,18 @@ class TransactionStore(BaseWalletStore):
                 batch_params = params + batch_etx_ids
                 batch_query = (query +
                     " AND Key IN ({0})".format(",".join("?" for k in batch_etx_ids)))
-                cursor = db.execute(batch_query, batch_params)
+                cursor = self._db.execute(batch_query, batch_params)
                 _collect_results(cursor, results)
                 etx_ids = etx_ids[batch_size:]
         else:
-            cursor = db.execute(query, params)
+            cursor = self._db.execute(query, params)
             _collect_results(cursor, results)
         return results
 
     @tprofiler
     def get_proof(self, tx_id: str) -> Optional[TxProof]:
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
-        cursor = db.execute(
+        cursor = self._db.execute(
             "SELECT ProofData FROM Transactions "+
             "WHERE GroupId=? AND DateDeleted is NULL AND Key=?", [self._group_id, etx_id])
         row = cursor.fetchone()
@@ -1021,13 +1092,12 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def get_ids(self, flags: Optional[int]=None,
             mask: Optional[int]=None) -> Set[str]:
-        db = self._get_db()
         query = "SELECT Key FROM Transactions WHERE GroupId=? AND DateDeleted IS NULL"
         clause, params = self._flag_clause(flags, mask)
         if clause:
             query += " AND "+ clause
         results = []
-        for t in db.execute(query, [ self._group_id ] + params):
+        for t in self._db.execute(query, [ self._group_id ] + params):
             results.append(self._decrypt_hex(t[0]))
         return set(results)
 
@@ -1037,9 +1107,7 @@ class TransactionStore(BaseWalletStore):
 
     @tprofiler
     def add_many(self, entries: List[Tuple[str, TxData, Optional[bytes], int]]) -> None:
-        db = self._get_db()
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
         # TODO: Make this a batch update.
         for tx_id, metadata, bytedata, flags in entries:
             etx_id = self._encrypt_hex(tx_id)
@@ -1049,11 +1117,11 @@ class TransactionStore(BaseWalletStore):
             if bytedata is not None:
                 flags |= TxFlags.HasByteData
             ebytedata = None if bytedata is None else self._encrypt(bytedata)
-            db.execute("INSERT INTO Transactions "+
+            self._db.execute("INSERT INTO Transactions "+
                 "(GroupId, Key, MetaData, ByteData, Flags, DateCreated, DateUpdated) "+
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 [self._group_id, etx_id, emetadata, ebytedata, flags, timestamp, timestamp])
-        db.commit()
+        self._db.commit()
         if len(entries) < 20:
             self._logger.debug("add %d transactions: %s", len(entries),
                 [ (a, b, byte_repr(c), TxFlags.to_repr(d)) for (a, b, c, d) in entries ])
@@ -1067,7 +1135,6 @@ class TransactionStore(BaseWalletStore):
     @tprofiler
     def update_many(self, entries: List[Tuple[str, TxData, bytes, int]]) -> None:
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
         datas = []
         for tx_id, metadata, bytedata, flags in entries:
@@ -1081,12 +1148,11 @@ class TransactionStore(BaseWalletStore):
                 ebytedata = self._encrypt(bytedata)
             datas.append((emetadata, ebytedata, flags, timestamp, self._group_id, etx_id))
 
-        db = self._get_db()
-        db.executemany(
+        self._db.executemany(
             "UPDATE Transactions SET MetaData=?,ByteData=?,Flags=?,DateUpdated=? "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
             datas)
-        db.commit()
+        self._db.commit()
         self._logger.debug("update %d transactions: %s", len(entries),
             [ (a, b, byte_repr(c), TxFlags.to_repr(d)) for (a, b, c, d) in entries ])
 
@@ -1101,7 +1167,6 @@ class TransactionStore(BaseWalletStore):
         # NOTE: This should only be used if it knows the existing flags column value, it should
         # preserve the state, bytedata and proofdata flags if it does not intend to clear them.
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
         datas = []
         for tx_id, data, flags in entries:
@@ -1109,12 +1174,11 @@ class TransactionStore(BaseWalletStore):
             metadata_bytes, flags = self._pack_data(data, flags)
             emetadata = self._encrypt(metadata_bytes)
             datas.append((emetadata, flags, timestamp, self._group_id, etx_id))
-        db = self._get_db()
-        vv = db.executemany(
+        self._db.executemany(
             "UPDATE Transactions SET MetaData=?,Flags=?,DateUpdated=? "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
             datas)
-        db.commit()
+        self._db.commit()
         self._logger.debug("update %d transactions: %s", len(entries),
             [ (a, b, TxFlags.to_repr(c)) for (a, b, c) in entries ])
 
@@ -1122,58 +1186,50 @@ class TransactionStore(BaseWalletStore):
     def update_flags(self, tx_id: str, flags: int,
             mask: Optional[int]=TxFlags.Unset) -> None:
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
-        db.execute("UPDATE Transactions SET Flags=((Flags&?)|?), DateUpdated=? "+
+        self._db.execute("UPDATE Transactions SET Flags=((Flags&?)|?), DateUpdated=? "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
             [mask, flags, timestamp, self._group_id, etx_id])
-        db.commit()
+        self._db.commit()
         self._logger.debug("update_flags '%s'", tx_id)
 
     @tprofiler
     def update_proof(self, tx_id: str, proof: TxProof) -> None:
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
         etx_id = self._encrypt_hex(tx_id)
         raw = self._pack_proof(proof)
         eraw = self._encrypt(raw)
-        db = self._get_db()
-        db.execute(
+        self._db.execute(
             "UPDATE Transactions SET ProofData=?, DateUpdated=?, Flags=(Flags|?) "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
             [eraw, timestamp, TxFlags.HasProofData, self._group_id, etx_id])
-        db.commit()
+        self._db.commit()
         self._logger.debug("updated %d transaction proof '%s'", 1, tx_id)
 
     @tprofiler
     def delete(self, tx_id: str) -> None:
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
         etx_id = self._encrypt_hex(tx_id)
-        db = self._get_db()
-        db.execute("UPDATE Transactions SET DateDeleted=? "+
+        self._db.execute("UPDATE Transactions SET DateDeleted=? "+
             "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
             [timestamp, self._group_id, etx_id])
-        db.commit()
+        self._db.commit()
         self._logger.debug("deleted %d transaction '%s'", 1, tx_id)
 
     @tprofiler
     def delete_many(self, tx_ids: Iterable[str]) -> None:
         # TODO: Integrate this with delete and look at using executemany.
         timestamp = self._get_current_timestamp()
-        self._write_timestamp = timestamp
 
-        db = self._get_db()
         for tx_id in tx_ids:
             etx_id = self._encrypt_hex(tx_id)
-            db.execute("UPDATE Transactions SET DateDeleted=? "+
+            self._db.execute("UPDATE Transactions SET DateDeleted=? "+
                 "WHERE GroupId=? AND Key=? AND DateDeleted IS NULL",
                 [timestamp, self._group_id, etx_id])
-        db.commit()
+        self._db.commit()
         self._logger.debug("deleted %d transactions", len(tx_ids))
 
 
@@ -1758,15 +1814,15 @@ class TxCache:
 
 
 class WalletData:
-    def __init__(self, wallet_path: str, aeskey: bytes, subwallet_id: int,
+    def __init__(self, db_context: DatabaseContext, aeskey: bytes, subwallet_id: int,
             migration_context: Optional[MigrationContext]=None) -> None:
-        self.tx_store = TransactionStore(wallet_path, aeskey, subwallet_id,
+        self.tx_store = TransactionStore(db_context, aeskey, subwallet_id,
             migration_context)
-        self.txin_store = TransactionInputStore(wallet_path, aeskey, subwallet_id,
+        self.txin_store = TransactionInputStore(db_context, aeskey, subwallet_id,
             migration_context)
-        self.txout_store = TransactionOutputStore(wallet_path, aeskey, subwallet_id,
+        self.txout_store = TransactionOutputStore(db_context, aeskey, subwallet_id,
             migration_context)
-        self.misc_store = ObjectKeyValueStore("HotData", wallet_path, aeskey, subwallet_id,
+        self.misc_store = ObjectKeyValueStore("HotData", db_context, aeskey, subwallet_id,
             migration_context)
 
         self.tx_cache = TxCache(self.tx_store)
@@ -1780,7 +1836,7 @@ class WalletData:
         self.misc_store.close()
 
     @property
-    def tx(self) -> TransactionStore:
+    def tx(self) -> TxCache:
         return self.tx_cache
 
     @property

--- a/electrumsv/wallet_database.py
+++ b/electrumsv/wallet_database.py
@@ -11,7 +11,6 @@ is out of date.
 """
 from abc import ABC, abstractmethod
 from collections import namedtuple, deque
-from copy import deepcopy
 from io import BytesIO
 import json
 import queue
@@ -1465,9 +1464,9 @@ class TxCache:
                 new_flags |= TxFlags.HasByteData
             if (entry.metadata == new_metadata and entry.bytedata == new_bytedata and
                     entry.flags == new_flags):
-                self.logger.debug("_update: skipped %s %r %s %r %s %s", tx_id, metadata,
-                    TxFlags.to_repr(flags), new_metadata, byte_repr(new_bytedata),
-                    entry.is_bytedata_cached())
+                #self.logger.debug("_update: skipped %s %r %s %r %s %s", tx_id, metadata,
+                #    TxFlags.to_repr(flags), new_metadata, byte_repr(new_bytedata),
+                #    entry.is_bytedata_cached())
                 skipped_update_ids.add(tx_id)
             else:
                 self._validate_new_flags(new_flags)
@@ -2067,6 +2066,13 @@ class WalletData:
     @property
     def utxos(self) -> UTXOCache:
         return self.utxo_cache
+
+    @utxos.setter
+    def utxos(self, value):
+        if isinstance(value, list):
+            self.utxo_cache = UTXOCache(value)
+        else:
+            self.utxo_cache = value
 
     @property
     def misc(self) -> ObjectKeyValueStore:

--- a/electrumsv/wallet_database.py
+++ b/electrumsv/wallet_database.py
@@ -1946,7 +1946,7 @@ class UTXOCache(deque):
 
         self.logger.debug("updating utxo cache for %s", tx.txid())
         # Add new utxos to cache
-        new_utxos = self.extract_utxos_from_tx_entry(txid, tx, tx_cache_entry)
+        new_utxos = self.extract_utxos_from_tx_entry(tx.txid(), tx, tx_cache_entry)
         self.extend(new_utxos)
 
     def undo_add_from_tx_entry(self, tx_cache_entry: TxCacheEntry) -> None:
@@ -1978,7 +1978,9 @@ class UTXOCache(deque):
         if len(utxos_to_add_back) == 0 or utxos_to_add_back is None:
             return
 
-        # avoid duplicate additions
+        # avoid duplicate additions (This is a slow operation
+        # but failure to broadcast should be
+        # a rare event
         elif utxos_to_add_back not in self:
             # extendleft because the idea is to keep the deque ordered
             # and pop used utxos from left, append new utxos to right side.

--- a/electrumsv/wallet_database.py
+++ b/electrumsv/wallet_database.py
@@ -1895,8 +1895,8 @@ class UTXOCache(deque):
     """Avoids needless re-calculation of utxo set (for every transaction).
 
     Freezing / unfreezing mechanics can be employed and if utxos are frozen + consumed
-    from 'left side' of deque, this will still be (close to O(1)) fast but for optimal performance, utxos
-    can be removed / added back to the cache in lieu of freezing / unfreezing.
+    from 'left side' of deque, this will still be (close to O(1)) fast but for optimal performance,
+    utxos can be removed / added back to the cache in lieu of freezing / unfreezing.
     """
 
     def __init__(self, utxos: List[UTXO] = (), maxlen=None):

--- a/electrumsv/wallet_database.py
+++ b/electrumsv/wallet_database.py
@@ -1477,7 +1477,7 @@ class TxCache:
             ]
             self._store.update_many(update_entries)
 
-        return set([ t[0] for t in actual_updates ]) | set(skipped_update_ids)
+        return set(actual_updates) | set(skipped_update_ids)
 
     def update_or_add(self, upadds: List[Tuple[str, TxData, Optional[bytes], int]]) -> None:
         # We do not require that all updates are applied, because the subset that do not
@@ -1486,6 +1486,7 @@ class TxCache:
             updated_ids = self._update(upadds, update_all=False)
             if len(updated_ids) != len(upadds):
                 self._add([ t for t in upadds if t[0] not in updated_ids ])
+            return updated_ids
 
     def update_flags(self, tx_id: str, flags: int, mask: Optional[int]=None) -> None:
         # This is an odd function. It logical ors metadata flags, but replaces the other


### PR DESCRIPTION
Hi. I've noticed that tx creation is really slow under heavy load.

This adds a utxo cache to avoid unnecessary re-calculation of utxo set for *every transaction* (where it iterates over every address and the history...).

It also makes use of the Tx State Flag system (StateSigned | StateDispatched | StateCleared | StateSettled | StateReceived) and updates the transaction and TxCacheEntry(s) accordingly at each stage.

Let me know if this fits in with your road map and /or any suggestions / modifications.

PS: After work I'll make pylint happy and remove the annotations import for python36 compatibility

I also am now wondering if an OrderedDict might be more suitable than a deque... not sure yet though... 