### PR TITLE
fix coinchooser (inappropriately consolidating utxos)

### DIFF
--- a/electrumsv/coinchooser.py
+++ b/electrumsv/coinchooser.py
@@ -261,7 +261,7 @@ class CoinChooserPrivacy(CoinChooserRandom):
     '''
 
     def keys(self, coins):
-        return [coin.script_sig for coin in coins]
+        return [coin.keyinstance_id for coin in coins]
 
     def penalty_func(self, tx):
         out_values = [output.value for output in tx.outputs]

--- a/electrumsv/gui/qt/account_wizard.py
+++ b/electrumsv/gui/qt/account_wizard.py
@@ -2,7 +2,7 @@ import concurrent
 import enum
 from typing import Any, List, Optional, Sequence, Tuple
 
-from bitcoinx import bip32_decompose_chain_string, bip32_is_valid_chain_string
+from bitcoinx import bip32_decompose_chain_string
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtGui import QPainter, QPalette, QPen, QPixmap, QTextOption
 from PyQt5.QtWidgets import (

--- a/electrumsv/transaction.py
+++ b/electrumsv/transaction.py
@@ -239,6 +239,7 @@ class XTxInput(TxInput):
     threshold: int = attr.ib(default=0)
     signatures: List[bytes] = attr.ib(default=attr.Factory(list))
     script_type: ScriptType = attr.ib(default=ScriptType.NONE)
+    keyinstance_id: Optional[int] = attr.ib(default=None)
 
     @classmethod
     def read_extended(cls, read):
@@ -320,9 +321,10 @@ class XTxInput(TxInput):
     def __repr__(self) -> str:
         return (
             f'XTxInput(prev_hash="{hash_to_hex_str(self.prev_hash)}", prev_idx={self.prev_idx}, '
-            f'script_sig="{self.script_sig}", sequence={self.sequence}), value={self.value} '
+            f'script_sig="{self.script_sig}", sequence={self.sequence}), value={self.value}, '
             f'threshold={self.threshold}, '
-            f'script_type={self.script_type}, x_pubkeys={self.x_pubkeys})'
+            f'script_type={self.script_type}, x_pubkeys={self.x_pubkeys}), '
+            f'keyinstance_id={self.keyinstance_id}'
         )
 
 @attr.s(slots=True, repr=False)

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -134,6 +134,7 @@ class UTXO:
             signatures=[NO_SIGNATURE] * threshold,
             x_pubkeys=account.get_xpubkeys_for_id(self.keyinstance_id),
             value=self.value,
+            keyinstance_id=self.keyinstance_id
         )
 
 


### PR DESCRIPTION
Simple bug fix.
Transaction creation is inappropriately consolidating all utxos down to a single change 'address'
It is caused by this part in `CoinChooserPrivacy` 

```
    def keys(self, coins):
        return [coin.script_sig for coin in coins]
```

The problem is that `coin.script_sig` represents an **empty string while the transaction is unsigned instead of a unique value to act as a dictionary key**. So all utxos are placed into one big bucket. 
Previously this was `coin.address` and was used as the key in a dictionary for 'bucketizing' coins to group them by scripthash and make it an all-or-nothing event if spending occurs.

I propose:
- Adding a `keyinstance_id` field to the `XTxInput` and using this as the unique dictionary key for 'bucketizing'.

If my understanding is correct, this should work fine for any wallet type.

That is to say it looks like with the latest database overhaul, 
1 `keyinstance_id` corresponds to 1 pubkey and 1 unique P2PKH scripthash for a standard deterministic wallet
1 `keyinstance_id` corresponds to 3 pubkeys (for a 2 of 3 multisig) and **a single unique bare multisig scripthash** for a (bare) MultisigAccount type wallet.

If this is correct then `keyinstance_id` will do nicely.