### PR TITLE
remove 'height' field from utxos

### DIFF
--- a/electrumsv/gui/qt/utxo_list.py
+++ b/electrumsv/gui/qt/utxo_list.py
@@ -78,12 +78,13 @@ class UTXOList(MyTreeWidget):
         self.clear()
 
         for utxo in self._account.get_utxos():
+            metadata = self._account.get_transaction_metadata(utxo.tx_hash)
             prevout_str = utxo.key_str()
             prevout_str = prevout_str[0:10] + '...' + prevout_str[-2:]
             label = self._account.get_transaction_label(utxo.tx_hash)
             amount = self._main_window.format_amount(utxo.value, whitespaces=True)
             utxo_item = SortableTreeWidgetItem(
-                [ prevout_str, label, amount, str(utxo.height) ])
+                [ prevout_str, label, amount, str(metadata.height) ])
             # set this here to avoid sorting based on Qt.UserRole+1
             utxo_item.DataRole = Qt.UserRole+100
             for col in (0, 2):


### PR DESCRIPTION
As discussed. Helping tidy up some loose ends. The overhead of keeping this up-to-date in cache is unacceptable / unnecessary.

We already have a transaction cache that can provide this metadata as needed.

Also, with the new way of doing things after the database overhaul the height of utxos is not maintained anymore anyway so it only causes problems to keep it in (e.g. **get_balance()** does not return coins as confirmed even though they actually are (because it depends on utxo.height which remains at 0 or -1 until ESV is restarted and utxo re-loaded from database).

I need this change for the restapi to behave how I want it (endpoints related to checking up on the confirmation status of coins or unconfirmed / confirmed balance calculation).