### PR TITLE
Fix Notification to scripthash timeouts

### DIFF
--- a/electrumsv/gui/qt/coinsplitting_tab.py
+++ b/electrumsv/gui/qt/coinsplitting_tab.py
@@ -133,7 +133,8 @@ class CoinSplittingTab(QWidget):
             elif result == RESULT_DUST_TIMEOUT:
                 self._main_window.show_error(_("It took too long to get the dust from the faucet."))
             else:
-                self._main_window.show_error(_("Unexpected situation. You should not even be here."))
+                self._main_window.show_error(_("Unexpected situation. You should not even be "
+                                               "here."))
             self._cleanup_tx_final()
         finally:
             self._cleanup_tx_created()

--- a/electrumsv/restapi.py
+++ b/electrumsv/restapi.py
@@ -10,7 +10,7 @@ from .app_state import app_state
 from .util import to_bytes, to_string, constant_time_compare
 
 # Supported networks in restapi url
-MAINET = 'main'
+MAINNET = 'main'
 TESTNET = 'test'
 SCALINGTESTNET = 'stn'
 
@@ -24,10 +24,10 @@ def get_network_type():
     app_state = get_app_state()
     if app_state.config.get('testnet'):
         return TESTNET
-    if app_state.config.get('scalingtestnet'):
+    elif app_state.config.get('scalingtestnet'):
         return SCALINGTESTNET
     else:
-        return MAINET
+        return MAINNET
 
 
 class Errors:
@@ -161,7 +161,7 @@ class AiohttpServer(BaseAiohttpServer):
 
     @web.middleware
     async def check_network(self, request, handler):
-        supported_networks = [MAINET, SCALINGTESTNET, TESTNET]
+        supported_networks = [MAINNET, SCALINGTESTNET, TESTNET]
         network = request.match_info.get('network', None)
 
         # paths without {network} are okay


### PR DESCRIPTION
As discussed. Experiencing timeouts after 30.0 seconds when performing things like splitting 1 utxo -> 1000 utxos... when it gets to 500 / 1000 new scripthashes they all start timing out because each call to `on_status_changed` takes too long to complete.

This fix kicks the `on_status_changed` call over into a worker coroutine that consumes from a queue.

By the way - I timed `_on_status_changed` and it is taking about 1 - 1.4 seconds each time... which I don't think was the case with a 'lightweight' (fewer keys, fewer utxos wallet) - so that'll be the next thing 😄 