### PR TITLE
Running multiple wallets simultaneously - bug fix

### DIFF
--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -32,7 +32,7 @@ import re
 import ssl
 import stat
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 import certifi
 from aiorpcx import (
@@ -756,47 +756,12 @@ class SVSession(RPCSession):
             async with TaskGroup() as group:
                 if is_main_server:
                     self.logger.info('using as main server')
-                    await group.spawn(self.subscribe_accounts)
                     await group.spawn(self._main_server_batch)
                 await group.spawn(self._ping_loop)
                 await self._closed_event.wait()
                 await group.cancel_remaining()
         finally:
             await self._network.session_closed(self)
-
-    async def subscribe_account(self, account, triples=None):
-        if triples is None:
-            triples = [ (k, script_type, scripthash_hex(script))
-                for k in account.existing_active_keys()
-                for script_type, script in account.get_possible_scripts_for_id(k) ]
-            self.logger.info(f'subscribing to {len(triples):,d} existing keys for {account}')
-        else:
-            self.logger.info(f'subscribing to {len(triples):,d} keys for {account}')
-            # If account was unsubscribed in the meantime keep it that way
-            if account not in self._subs_by_account:
-                return
-        await self.subscribe_to_triples(account, triples)
-
-    async def subscribe_accounts(self):
-        '''When switching main server or when initially connected to the main server, send script
-        hash subs to the new main session.
-
-        Raises: RPCError, TaskTimeout
-        '''
-        self.logger.debug("subscribe_accounts")
-        subs_by_account = self._subs_by_account
-        keyinstance_map = self._keyinstance_map
-        SVSession._keyinstance_map = {}
-        SVSession._subs_by_account = {account: [] for account in subs_by_account}
-
-        async with TaskGroup() as group:
-            for account in list(subs_by_account):
-                triples = [(*keyinstance_map[sh], sh) for sh in subs_by_account[account]]
-                await group.spawn(self.subscribe_account, account, triples)
-
-        for account in list(subs_by_account):
-            # there are no accounts at initial startup of ESV
-            self._network.account_session_subs_done_events[account].set()
 
     async def headers_at_heights(self, heights):
         '''Raises: MissingHeader, DisconnectSessionError, BatchError, TaskTimeout'''
@@ -928,7 +893,6 @@ class Network(TriggeredCallbacks):
         self.check_main_chain_event = app_state.async_.event()
         self.stop_network_event = app_state.async_.event()
         self.shutdown_complete_event = app_state.async_.event()
-        self.account_session_subs_done_events = {}  # {account: asyncio.Event()}
 
         # Add an account, remove an account, or redo all account verifications
         self.account_jobs = app_state.async_.queue()
@@ -1069,8 +1033,6 @@ class Network(TriggeredCallbacks):
         self.main_server = server
         self.check_main_chain_event.set()
         main_session = self.main_session()
-        if main_session:
-            await main_session.subscribe_accounts()
         # Disconnect the old main session, if any, in order to lose scripthash
         # subscriptions.
         if old_main_session:
@@ -1231,11 +1193,7 @@ class Network(TriggeredCallbacks):
 
     async def _monitor_active_keys(self, account) -> None:
         '''Raises: RPCError, TaskTimeout'''
-        all_keys = set(account.existing_active_keys())
-        session = await self._main_session()
-        monitored_keyinstance_ids = set([v[0] for v in session._keyinstance_map.values()])
-        additional_keys = all_keys - monitored_keyinstance_ids
-
+        additional_keys = set(account.existing_active_keys())
         while True:
             session = await self._main_session()
             session.logger.info(f'subscribing to {len(additional_keys):,d} new keys for {account}')
@@ -1260,15 +1218,8 @@ class Network(TriggeredCallbacks):
     async def _maintain_account(self, account):
         '''Put all tasks for a single account in a group so they can be cancelled together.'''
         logger.info(f'maintaining account {account}')
-
-        self.account_session_subs_done_events[account] = app_state.async_.event()
-
         try:
             while True:
-                if SVSession._subs_by_account.get(account):
-                    # event forces subscribe_accounts() before _monitor_active_keys()
-                    await self.account_session_subs_done_events[account].wait()
-                    self.account_session_subs_done_events[account].clear()
                 try:
                     async with TaskGroup() as group:
                         await group.spawn(self._monitor_txs, account)
@@ -1280,6 +1231,7 @@ class Network(TriggeredCallbacks):
                     blacklist = isinstance(error, DisconnectSessionError) and error.blacklist
                     session = self.main_session()
                     if session:
+                        SVSession._subs_by_account[account] = []
                         await session.disconnect(str(error), blacklist=blacklist)
         finally:
             await SVSession.unsubscribe_account(account, self.main_session())

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -821,9 +821,7 @@ class SVSession(RPCSession):
                 account.response_count += 1
                 account.progress_event.set()
 
-        if len(set(subs)) != len(subs):
-            seen = set(); duplicates = set(x for x in subs if x in seen or seen.add(x))
-            logger.error("subscribed to the same keys twice for: %s", duplicates)
+        assert len(set(subs)) == len(subs), "account subscribed to the same keys twice"
 
     async def unsubscribe_from_pairs(self, account, pairs) -> None:
         '''pairs is an iterable of (keyinstance_id, script_hash) pairs.


### PR DESCRIPTION
This PR changes the single global event `session_subs_complete` to a dictionary of _per account_ events to allow for running multiple accounts simultaneously and maintaining their respective key subscriptions.

This is a fix for issue: #348 and completes the bug fix for #150 