### PR TITLE
Add detection of used keys and deactivate them (unsubscribe)

### DIFF
--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -144,6 +144,7 @@ class KeyInstanceFlag(IntFlag):
     # The mask used to load the subset of keys that are actively cached by accounts.
     CACHE_MASK = IS_ACTIVE
     ACTIVE_MASK = IS_ACTIVE | USER_SET_ACTIVE
+    INACTIVE_MASK = ~ACTIVE_MASK
     ALLOCATED_MASK = IS_PAYMENT_REQUEST
 
 

--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -144,7 +144,7 @@ class KeyInstanceFlag(IntFlag):
     # The mask used to load the subset of keys that are actively cached by accounts.
     CACHE_MASK = IS_ACTIVE
     ACTIVE_MASK = IS_ACTIVE | USER_SET_ACTIVE
-    INACTIVE_MASK = ~ACTIVE_MASK
+    INACTIVE_MASK = ~IS_ACTIVE
     ALLOCATED_MASK = IS_PAYMENT_REQUEST
 
 

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -1914,7 +1914,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
         if self.question(_("Do you want to remove this key from your wallet?") + extra_text):
             keyinstance = self._account.get_keyinstance(key_id)
             # This if successful will unload the key from the account (not delete).
-            if account.set_key_active(key_id, False):
+            if account.set_key_active_state(key_id, False):
                 if self.key_view is not None:
                     self.key_view.remove_keys([ keyinstance ])
                 self.history_view.update_tx_list()

--- a/electrumsv/gui/qt/preferences.py
+++ b/electrumsv/gui/qt/preferences.py
@@ -408,6 +408,8 @@ class PreferencesDialog(QDialog):
         options_vbox.addWidget(usechange_cb)
         options_vbox.addWidget(multiple_cb)
 
+        # Todo - add ability to set deactivation of used keys
+
         transaction_cache_size = wallet.get_cache_size_for_tx_bytedata()
         # nz_label = HelpLabel(_('Transaction Cache Size (MB)') + ':',
         #     _("This allows setting a per-wallet limit on the amount of transaction data cached "

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1199,6 +1199,7 @@ class Network(TriggeredCallbacks):
             if wanted_proof_map:
                 coros.append(self._request_proofs(account, wanted_proof_map))
             if not coros:
+                account.detect_used_keys()
                 await account.txs_changed_event.wait()
                 account.txs_changed_event.clear()
 


### PR DESCRIPTION
I would like to test this more but so far seems to be working.

Haven't profiled it but qualitatively doesn't seem to be slowing anything down - could make some components more efficient without much trouble though (like iterating through the utxo set for each key to get utxo set for a given key... is not very efficient and it's possible could be a bottleneck at scale - solution would be to get key history - probably only 2 txs and then check the utxo set for only those two outputs.).