### PR TITLE
Fix text overlapping icons in edit box.

### DIFF
--- a/electrumsv/gui/qt/util.py
+++ b/electrumsv/gui/qt/util.py
@@ -669,6 +669,12 @@ class ButtonsLineEdit(XLineEdit, ButtonsWidget):
     def resizeEvent(self, e):
         o = QLineEdit.resizeEvent(self, e)
         self.resizeButtons()
+
+        buttons_width = 0
+        for button in self.buttons:
+            buttons_width += button.size().width()
+        self.setTextMargins(0, 0, buttons_width, 0)
+
         return o
 
 class ButtonsTextEdit(QPlainTextEdit, ButtonsWidget):


### PR DESCRIPTION
> The buttons in the line edit in the wallet information dialog overlay the text in the line edit. It should be possible to style these “button edit” widgets to have a padding on the right hand side that prevents text from going under the buttons.