### PR TITLE
add key deactivation

### DIFF
--- a/.azure-pipelines/jobs-run-python-tests.yml
+++ b/.azure-pipelines/jobs-run-python-tests.yml
@@ -15,7 +15,7 @@ jobs:
       architecture: x64
   - template: prepare-general-environment.yml
   - script: |
-      python3 -m pip install pytest pytest-cov pytest-timeout
+      python3 -m pip install pytest pytest-cov pytest-timeout pytest-mock
       python3 -m pytest -v -v -v --doctest-modules --junitxml=junit/test-results.xml --cov=electrumsv --cov-report=xml --cov-report=html electrumsv/tests
     displayName: 'Test with pytest'
   - script: |

--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -144,6 +144,7 @@ class KeyInstanceFlag(IntFlag):
     # The mask used to load the subset of keys that are actively cached by accounts.
     CACHE_MASK = IS_ACTIVE
     ACTIVE_MASK = IS_ACTIVE | USER_SET_ACTIVE
+    INACTIVE_MASK = ~IS_ACTIVE
     ALLOCATED_MASK = IS_PAYMENT_REQUEST
 
 

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -1940,7 +1940,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
         if self.question(_("Do you want to remove this key from your wallet?") + extra_text):
             keyinstance = self._account.get_keyinstance(key_id)
             # This if successful will unload the key from the account (not delete).
-            if account.set_key_active(key_id, False):
+            if account.set_key_active_state(key_id, False):
                 if self.key_view is not None:
                     self.key_view.remove_keys([ keyinstance ])
                 self.history_view.update_tx_list()

--- a/electrumsv/gui/qt/preferences.py
+++ b/electrumsv/gui/qt/preferences.py
@@ -407,6 +407,7 @@ class PreferencesDialog(QDialog):
         options_vbox.addWidget(usechange_cb)
         options_vbox.addWidget(multiple_cb)
 
+        # Todo - add ability here to toggle deactivation of used keys - AustEcon
         transaction_cache_size = wallet.get_cache_size_for_tx_bytedata()
         # nz_label = HelpLabel(_('Transaction Cache Size (MB)') + ':',
         #     _("This allows setting a per-wallet limit on the amount of transaction data cached "

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1200,6 +1200,7 @@ class Network(TriggeredCallbacks):
             if wanted_proof_map:
                 coros.append(self._request_proofs(account, wanted_proof_map))
             if not coros:
+                account.detect_used_keys()
                 await account.txs_changed_event.wait()
                 account.txs_changed_event.clear()
 

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -1200,7 +1200,7 @@ class Network(TriggeredCallbacks):
             if wanted_proof_map:
                 coros.append(self._request_proofs(account, wanted_proof_map))
             if not coros:
-                account.detect_used_keys()
+                account.poll_used_key_detection(every_n_seconds=20)
                 await account.txs_changed_event.wait()
                 account.txs_changed_event.clear()
 

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -1622,9 +1622,9 @@ class AbstractAccount:
         # update cache KeyInstanceFlag
         db_updates = []
         for key in keyinstances:
-            old_flags = key.flags
+            old_flags = KeyInstanceFlag(key.flags)
             if activate:
-                new_flags = old_flags | KeyInstanceFlag.IS_ACTIVE
+                new_flags = KeyInstanceFlag(old_flags | KeyInstanceFlag.IS_ACTIVE)
             else:
                 # if USER_SET_ACTIVE flag is set - this flag will remain
                 new_flags = old_flags & (KeyInstanceFlag.INACTIVE_MASK |

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -359,8 +359,8 @@ class AbstractAccount:
         assert key_allocation.derivation_type == DerivationType.BIP32_SUBPATH
         return json.dumps({ "subpath": key_allocation.derivation_path }).encode()
 
-    def set_key_active(self, key_id: int, is_active: bool) -> bool:
-        if is_active:
+    def set_key_active_state(self, key_id: int, set_active: bool) -> bool:
+        if set_active:
             raise NotImplementedError("TODO(rt12) BACKLOG")
             # TODO(rt12) BACKLOG If the key is already active, then flag it as user active.
 
@@ -814,8 +814,9 @@ class AbstractAccount:
             return
 
         with self.lock:
-            reorg_count = self._wallet._transaction_cache.apply_reorg(above_height)
+            reorg_count, updated_txs = self._wallet._transaction_cache.apply_reorg(above_height)
             self._logger.info(f'removing verification of {reorg_count} transactions')
+            self.reactivate_reorged_keys(updated_txs)
 
     def get_tx_height(self, tx_hash: bytes) -> Tuple[int, int, Union[int, bool]]:
         """ return the height and timestamp of a verified transaction. """
@@ -1591,6 +1592,98 @@ class AbstractAccount:
             self._activated_keys = []
         return result
 
+    def is_key_history_all_settled(self, keyinstance_id: int) -> bool:
+        hist = self.get_key_history(keyinstance_id, script_type=self.get_default_script_type())
+        if len(hist) < 2:
+            return False
+        for tx_id, tx_height in hist:
+            entry_flags = self._wallet._transaction_cache.get_flags(hex_str_to_hash(tx_id))
+            if entry_flags is None:
+                self._logger.error("transaction flags not found for keyinstance_id %s",
+                    keyinstance_id)
+                return False
+            if entry_flags & TxFlags.StateSettled == TxFlags.StateSettled:
+                continue
+            else:
+                return False
+        return True
+
+    def is_user_active(self, keyinstance_id: int) -> bool:
+        if self._keyinstances[keyinstance_id].flags & KeyInstanceFlag.USER_SET_ACTIVE != 0:
+            return True
+        return False
+
+    def is_used_key(self, keyinstance_id: int) -> bool:
+        # At least 2 txs in history, all confirmed, exclude user activated keys and...
+        # Note: zero balance requirement is satisfied via TransactionDelta table query.
+        if self.is_user_active(keyinstance_id):
+            return False
+        if not self.is_key_history_all_settled(keyinstance_id):
+            return False
+        return True
+
+    def detect_used_keys(self) -> None:
+        # Note: re-activation of keys is dealt with via:
+        #   a) reorg detection time - see self.reactivate_reorged_keys()
+        #   b) manual re-activation by the user
+        # Therefore, this function only needs to deal with deactivation
+        if not self._wallet._storage.get('deactivate_used_keys', False):
+            return
+        # Get all used keys with zero balance (of the ones that are currently active)
+        keyinstance_ids = self.existing_active_keys()
+        self._logger.debug("detect-used-keys: checking %s active keys for deactivation criteria",
+            len(keyinstance_ids))
+        with TransactionDeltaTable(self._wallet._db_context) as table:
+            candidate_used_keys = table.read_candidate_used_keys(self._id, keyinstance_ids)
+
+        used_keyinstances = []
+        if len(candidate_used_keys) != 0:
+            for keyinstance_id in candidate_used_keys:
+                if self.is_used_key(keyinstance_id[0]):
+                    with self._deactivated_keys_lock:
+                        self._deactivated_keys.append(keyinstance_id[0])
+                        self._deactivated_keys_event.set()
+                    key = self._keyinstances[keyinstance_id[0]]
+                    used_keyinstances.append(key)
+
+        self._logger.debug("found %s used keys for deactivation", len(used_keyinstances))
+        if len(used_keyinstances) != 0:
+            self.update_key_activation_state(used_keyinstances, activate=False)
+
+    def update_key_activation_state(self, keyinstances: List[KeyInstanceRow], activate: bool):
+        # update cache KeyInstanceFlag
+        db_updates = []
+        for key in keyinstances:
+            old_flags = key.flags
+            if activate:
+                new_flags = cast(KeyInstanceFlag, old_flags | KeyInstanceFlag.IS_ACTIVE)
+            else:
+                # will not deactivate if USER_SET_ACTIVE flag is set
+                new_flags = cast(KeyInstanceFlag, old_flags & KeyInstanceFlag.INACTIVE_MASK)
+            self._keyinstances[key.keyinstance_id] = KeyInstanceRow(key.keyinstance_id,
+                self.get_id(),
+                key.masterkey_id, key.derivation_type, key.derivation_data, key.script_type,
+                new_flags, key.description)
+            db_updates.append((new_flags, key.keyinstance_id))
+
+        # update db
+        self._wallet.update_keyinstance_flags(db_updates)
+
+    def reactivate_reorged_keys(self, updated_txs: List[bytes]):
+        # There's an edge case where a tx may get dropped from the mempool despite being
+        # included in a recent block (very unlikely though). We can only detect
+        # such an event via observing a change in history - i.e. a dropped tx). Therefore we should
+        # ideally re-activate all of the reorged keys by default and deactivate when confirmed
+        # again.
+        txs = self._wallet._transaction_cache.get_transaction_datas(tx_hashes=updated_txs)
+        set_key_ids = set()
+        for tx_hash in txs.keys():
+            key_ids = self._sync_state.get_transaction_key_ids(hash_to_hex_str(tx_hash))
+            for key in key_ids:
+                set_key_ids.add(key)
+        for key_id in set_key_ids:
+            self.set_key_active_state(key_id=key_id, set_active=True)
+
     async def new_deactivated_keys(self) -> List[int]:
         await self._deactivated_keys_event.wait()
         self._deactivated_keys_event.clear()
@@ -2121,7 +2214,7 @@ class Wallet(TriggeredCallbacks):
         with KeyInstanceTable(self._db_context) as table:
             all_account_keys: Dict[int, List[KeyInstanceRow]] = defaultdict(list)
             keyinstances = {}
-            for row in table.read(mask=KeyInstanceFlag.IS_ACTIVE):
+            for row in table.read():
                 keyinstances[row.keyinstance_id] = row
                 all_account_keys[row.account_id].append(row)
 
@@ -2519,6 +2612,15 @@ class Wallet(TriggeredCallbacks):
 
     def set_use_change(self, enabled: bool) -> None:
         return self._storage.put('use_change', enabled)
+
+    def set_deactivate_used_keys(self, enabled: bool) -> None:
+        current_setting = self._storage.get('deactivate_used_keys', None)
+        if not enabled and current_setting is True:
+            # ensure all keys are re-activated
+            for account in self.get_accounts():
+                account.update_key_activation_state(list(account._keyinstances.values()), True)
+
+        return self._storage.put('deactivate_used_keys', enabled)
 
     def get_multiple_change(self) -> bool:
         return self._storage.get('multiple_change', False)

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -227,6 +227,7 @@ class AbstractAccount:
         self.request_count = 0
         self.response_count = 0
         self.progress_event = app_state.async_.event()
+        self.last_poll_time = None
 
         self._load_sync_state()
         self._utxos: Dict[Tuple[bytes, int], UTXO] = {}
@@ -1591,6 +1592,12 @@ class AbstractAccount:
             result = self._activated_keys
             self._activated_keys = []
         return result
+
+    def poll_used_key_detection(self, every_n_seconds):
+        if self.last_poll_time is None or \
+                time.time() - self.last_poll_time > every_n_seconds:
+            self.last_poll_time = time.time()
+            self.detect_used_keys()
 
     def detect_used_keys(self) -> None:
         # Note: re-activation of keys is dealt with via:

--- a/electrumsv/wallet_database/cache.py
+++ b/electrumsv/wallet_database/cache.py
@@ -6,7 +6,7 @@ there will be no reads or
 
 import threading
 import time
-from typing import cast, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import cast, Dict, Iterable, List, Optional, Sequence, Tuple, Any
 
 from bitcoinx import double_sha256, hash_to_hex_str
 
@@ -507,7 +507,8 @@ class TransactionCache:
             if 0 < cast(int, metadata.height) <= watermark_height ]
 
     def apply_reorg(self, reorg_height: int,
-            completion_callback: Optional[CompletionCallbackType]=None) -> None:
+            completion_callback: Optional[CompletionCallbackType]=None) \
+            -> Tuple[int, List[bytes]]:
         fetch_flags = TxFlags.StateSettled
         fetch_mask = TxFlags.StateSettled
         unverify_mask = ~(TxFlags.HasHeight | TxFlags.HasPosition | TxFlags.HasProofData |
@@ -530,3 +531,4 @@ class TransactionCache:
             if len(store_updates):
                 self._store.update_metadata(store_updates,
                     completion_callback=completion_callback)
+            return len(store_updates), [tx_hash for tx_hash, metadata, flags in store_updates]

--- a/electrumsv/wallet_database/cache.py
+++ b/electrumsv/wallet_database/cache.py
@@ -6,7 +6,7 @@ there will be no reads or
 
 import threading
 import time
-from typing import cast, Dict, Iterable, List, Optional, Sequence, Tuple, Any
+from typing import cast, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from bitcoinx import double_sha256, hash_to_hex_str
 

--- a/electrumsv/wallet_database/tables.py
+++ b/electrumsv/wallet_database/tables.py
@@ -2,7 +2,7 @@ from io import BytesIO
 import json
 import sqlite3
 import time
-from typing import Any, Dict, Iterable, NamedTuple, Optional, List, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, NamedTuple, Optional, List, Sequence, Tuple
 
 import bitcoinx
 from bitcoinx import hash_to_hex_str
@@ -616,7 +616,7 @@ class KeyInstanceRow(NamedTuple):
     derivation_type: DerivationType
     derivation_data: bytes
     script_type: ScriptType
-    flags: Union[KeyInstanceFlag, int]
+    flags: KeyInstanceFlag
     description: Optional[str]
 
 
@@ -794,11 +794,11 @@ class TransactionDeltaTable(BaseWalletStore):
         "FROM TransactionDeltas AS TD "
         "INNER JOIN KeyInstances AS KI ON TD.keyinstance_id = KI.keyinstance_id AND "
             "KI.account_id = ?")
-    READ_CANDIDATE_USED_KEYS = ("""
+    READ_CANDIDATE_USED_KEYS = (f"""
         WITH constants AS (
-            SELECT 1<<0 AS is_active_flag,
-                   1<<8 AS user_set_active_flag,
-                   1<<21 AS settled_tx_flag
+            SELECT {KeyInstanceFlag.IS_ACTIVE} AS is_active_flag,
+                   {KeyInstanceFlag.USER_SET_ACTIVE} AS user_set_active_flag,
+                   {TxFlags.StateSettled} AS settled_tx_flag
             ),
              active_keys AS (
                 SELECT keyinstance_id, account_id, script_type, flags AS key_flags


### PR DESCRIPTION
- Ensure that key has a zero balance (via TransactionDelta query)
- Reactivates all keys if user toggles key deactivation back off again
- Added INACTIVE_MASK
- `reactivate_reorged_keys()` function reactivates all keys above reorg height
- Renamed a function to `set_key_active_state()` (more intuitive)
- Deactivating keys has unmasked an issue with loading only activated keys at startup (so for now will have to load all keyinstances to cache at startup)

This implementation is mostly about changing up the implementation of #365 to use a TransactionDelta table query for ensuring that 'used keys' do indeed have a zero balance (rather than layering on an additional in-memory tracking mechanic for 'unsettled_transactions' as in the #365 implementation.