### PR TITLE
Features/persist sqlite connection

### DIFF
--- a/electrumsv/storage.py
+++ b/electrumsv/storage.py
@@ -339,11 +339,11 @@ class DatabaseStore(AbstractStore):
     def upgrade(self: 'DatabaseStore', has_password: bool, new_password: str) \
             -> Optional['DatabaseStore']:
         from .wallet_database.migration import update_database
-        connection = self._db_context.acquire_connection()
+        connection = self._db_context.get_connection()
         try:
             update_database(connection)
         finally:
-            self._db_context.release_connection(connection)
+            self._db_context.put_connection(connection)
         # Refresh the cached data.
         self.attempt_load_data()
         assert MIGRATION_CURRENT == self.get("migration")

--- a/electrumsv/storage.py
+++ b/electrumsv/storage.py
@@ -339,11 +339,11 @@ class DatabaseStore(AbstractStore):
     def upgrade(self: 'DatabaseStore', has_password: bool, new_password: str) \
             -> Optional['DatabaseStore']:
         from .wallet_database.migration import update_database
-        connection = self._db_context.get_connection()
+        connection = self._db_context.acquire_connection()
         try:
             update_database(connection)
         finally:
-            self._db_context.put_connection(connection)
+            self._db_context.release_connection(connection)
         # Refresh the cached data.
         self.attempt_load_data()
         assert MIGRATION_CURRENT == self.get("migration")

--- a/electrumsv/tests/test_wallet_database.py
+++ b/electrumsv/tests/test_wallet_database.py
@@ -54,7 +54,7 @@ class TestWalletDataTable:
         cls.db_context = DatabaseContext(cls.db_filename)
         # We hold onto an open connection to ensure that the database persists for the
         # lifetime of the tests.
-        cls.db = cls.db_context.acquire_connection()
+        cls.db = cls.db_context.get_connection()
         create_database(cls.db)
         update_database(cls.db)
         cls.store = wallet_database.WalletDataTable(cls.db_context)
@@ -63,7 +63,7 @@ class TestWalletDataTable:
     def teardown_class(cls):
         del cls.store._get_current_timestamp
         cls.store.close()
-        cls.db_context.release_connection(cls.db)
+        cls.db_context.put_connection(cls.db)
         cls.db_context.close()
 
     def setup_method(self):
@@ -195,7 +195,7 @@ class TestTransactionCache:
         cls.db_context = DatabaseContext(cls.db_filename)
         # We hold onto an open connection to ensure that the database persists for the
         # lifetime of the tests.
-        cls.db = cls.db_context.acquire_connection()
+        cls.db = cls.db_context.get_connection()
         create_database(cls.db)
         update_database(cls.db)
         cls.store = wallet_database.TransactionTable(cls.db_context)
@@ -203,7 +203,7 @@ class TestTransactionCache:
     @classmethod
     def teardown_class(cls):
         cls.store.close()
-        cls.db_context.release_connection(cls.db)
+        cls.db_context.put_connection(cls.db)
         cls.db_context.close()
 
     def setup_method(self):
@@ -691,7 +691,7 @@ class TestSqliteWriteDispatcher:
     def setup_method(self):
         self.dispatcher = None
         self._logger = logs.get_logger("...")
-        class DbConnection:
+        class MockSqlite3Connection:
             def __enter__(self, *args, **kwargs):
                 pass
             def __exit__(self, *args, **kwargs):
@@ -699,9 +699,9 @@ class TestSqliteWriteDispatcher:
             def execute(self, query: str) -> None:
                 pass
         class DbContext:
-            def acquire_connection(self):
-                return DbConnection()
-            def release_connection(self, conn):
+            def get_connection(self):
+                return MockSqlite3Connection()
+            def put_connection(self, connection):
                 pass
         self.db_context = DbContext()
 

--- a/electrumsv/tests/test_wallet_database.py
+++ b/electrumsv/tests/test_wallet_database.py
@@ -54,7 +54,7 @@ class TestWalletDataTable:
         cls.db_context = DatabaseContext(cls.db_filename)
         # We hold onto an open connection to ensure that the database persists for the
         # lifetime of the tests.
-        cls.db = cls.db_context.get_connection()
+        cls.db = cls.db_context.acquire_connection()
         create_database(cls.db)
         update_database(cls.db)
         cls.store = wallet_database.WalletDataTable(cls.db_context)
@@ -63,7 +63,7 @@ class TestWalletDataTable:
     def teardown_class(cls):
         del cls.store._get_current_timestamp
         cls.store.close()
-        cls.db_context.put_connection(cls.db)
+        cls.db_context.release_connection(cls.db)
         cls.db_context.close()
 
     def setup_method(self):
@@ -195,7 +195,7 @@ class TestTransactionCache:
         cls.db_context = DatabaseContext(cls.db_filename)
         # We hold onto an open connection to ensure that the database persists for the
         # lifetime of the tests.
-        cls.db = cls.db_context.get_connection()
+        cls.db = cls.db_context.acquire_connection()
         create_database(cls.db)
         update_database(cls.db)
         cls.store = wallet_database.TransactionTable(cls.db_context)
@@ -203,7 +203,7 @@ class TestTransactionCache:
     @classmethod
     def teardown_class(cls):
         cls.store.close()
-        cls.db_context.put_connection(cls.db)
+        cls.db_context.release_connection(cls.db)
         cls.db_context.close()
 
     def setup_method(self):
@@ -699,9 +699,9 @@ class TestSqliteWriteDispatcher:
             def execute(self, query: str) -> None:
                 pass
         class DbContext:
-            def get_connection(self):
+            def acquire_connection(self):
                 return MockSqlite3Connection()
-            def put_connection(self, connection):
+            def release_connection(self, connection):
                 pass
         self.db_context = DbContext()
 

--- a/electrumsv/wallet_database/tables.py
+++ b/electrumsv/wallet_database/tables.py
@@ -56,10 +56,10 @@ class BaseWalletStore:
     def __init__(self, db_context: DatabaseContext) -> None:
         self._logger = logs.get_logger(self.LOGGER_NAME)
         self._db_context = db_context
-        self._db: sqlite3.Connection = db_context.get_connection()
+        self._db: sqlite3.Connection = db_context.acquire_connection()
 
     def close(self) -> None:
-        self._db_context.put_connection(self._db)
+        self._db_context.release_connection(self._db)
 
     def __enter__(self):
         return self

--- a/electrumsv/wallet_database/tables.py
+++ b/electrumsv/wallet_database/tables.py
@@ -56,11 +56,10 @@ class BaseWalletStore:
     def __init__(self, db_context: DatabaseContext) -> None:
         self._logger = logs.get_logger(self.LOGGER_NAME)
         self._db_context = db_context
-        self._db: sqlite3.Connection = db_context.acquire_connection()
+        self._db: sqlite3.Connection = db_context.get_connection()
 
     def close(self) -> None:
-        self._db_context.release_connection(self._db)
-        del self._db
+        self._db_context.put_connection(self._db)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
The commit message basically says it all...

I've attached some profiling data for your interest. This was mainly aimed at sync speeds and the  `process_key_usage` function which seems to be the main determinant. This commit takes it from around 0.009 -> 0.002 sec per call so gives quite a noticeable improvement given that 1 utxo splitting tx with 2000 outputs means the difference between 18 seconds and 4 seconds to get all sync'd up. 😃 It has a similar effect on high tx throughput wrt processing all of the pub-sub notifications.

[process_key_usage_much_faster.txt](https://github.com/electrumsv/electrumsv/files/4680439/process_key_usage_much_faster.txt)
