### PR TITLE
https://github.com/electrumsv/electrumsv/issues/438

### DIFF
--- a/electrumsv/gui/qt/util.py
+++ b/electrumsv/gui/qt/util.py
@@ -9,7 +9,7 @@ import weakref
 
 from aiorpcx import RPCError
 
-from PyQt5.QtCore import (pyqtSignal, Qt, QCoreApplication, QDir, QEvent, QLocale, QProcess,
+from PyQt5.QtCore import (pyqtSignal, Qt, QCoreApplication, QDir, QLocale, QProcess,
     QModelIndex, QSize, QTimer)
 from PyQt5.QtGui import QFont, QCursor, QIcon, QKeyEvent, QColor, QPalette, QPixmap, QResizeEvent
 from PyQt5.QtWidgets import (


### PR DESCRIPTION
Steps to reproduce bug:
1) create a RegTest wallet
2) generate coins directly to a receive address of this wallet **while the wallet is still actively running**
3) observe that the unmatured balance vs confirmed balance is incorrect (the coins show incorrectly as confirmed)
4) close wallet and restart
5) observe that it is now corrected...

Post-bug fix behaviour:
1) create a RegTest wallet
2) generate coins directly to a receive address of this wallet **while the wallet is still actively running**
3) observe that the unmatured balance remains correct