### PR TITLE
disable fickle functional tests until the REST API has a websocket to…

### DIFF
--- a/contrib/functional_tests/test_restapi.py
+++ b/contrib/functional_tests/test_restapi.py
@@ -126,51 +126,52 @@ class TestRestAPI:
 
         assert result.json() == expected_json
 
-    def test_get_utxos_and_top_up(self):
-        """
-        1) get coin state before
-        2) top up wallet
-        3) get coin state after
-        4) generate block to confirm coins
-        5) get coin state after block confirmation
-        """
-        result1 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                              f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
-        if result1.status_code != 200:
-            raise requests.exceptions.HTTPError(result1.text)
-
-        current_cleared_count = result1.json()['cleared_coins']
-        current_settled_count = result1.json()['settled_coins']
-
-        result2 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                              f'{self.TEST_WALLET_NAME}/1/topup_account')
-        if result2.status_code != 200:
-            raise requests.exceptions.HTTPError(result2.text)
-
-        time.sleep(10)
-        result3 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                              f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
-        if result3.status_code != 200:
-            raise requests.exceptions.HTTPError(result3.text)
-
-        # post-topup (no block mined)
-        assert (current_cleared_count + 1) == result3.json()['cleared_coins']
-        assert current_settled_count == result3.json()['settled_coins']
-
-        result4 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                               f'{self.TEST_WALLET_NAME}/1/generate_blocks')
-        if result4.status_code != 200:
-            raise requests.exceptions.HTTPError(result4.text)
-
-        time.sleep(10)
-        result5 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                               f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
-        if result5.status_code != 200:
-            raise requests.exceptions.HTTPError(result5.text)
-
-        # post-topup (block mined)
-        assert current_settled_count + current_cleared_count + 1 == result5.json()[
-            'settled_coins']
+    """Disabled test until websockets are implemented for waiting on tx processing"""
+    # def test_get_utxos_and_top_up(self):
+    #     """
+    #     1) get coin state before
+    #     2) top up wallet
+    #     3) get coin state after
+    #     4) generate block to confirm coins
+    #     5) get coin state after block confirmation
+    #     """
+    #     result1 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                           f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
+    #     if result1.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result1.text)
+    #
+    #     current_cleared_count = result1.json()['cleared_coins']
+    #     current_settled_count = result1.json()['settled_coins']
+    #
+    #     result2 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                           f'{self.TEST_WALLET_NAME}/1/topup_account')
+    #     if result2.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result2.text)
+    #
+    #     time.sleep(10)
+    #     result3 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                           f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
+    #     if result3.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result3.text)
+    #
+    #     # post-topup (no block mined)
+    #     assert (current_cleared_count + 1) == result3.json()['cleared_coins']
+    #     assert current_settled_count == result3.json()['settled_coins']
+    #
+    #     result4 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                            f'{self.TEST_WALLET_NAME}/1/generate_blocks')
+    #     if result4.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result4.text)
+    #
+    #     time.sleep(10)
+    #     result5 = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                            f'{self.TEST_WALLET_NAME}/1/utxos/coin_state')
+    #     if result5.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result5.text)
+    #
+    #     # post-topup (block mined)
+    #     assert current_settled_count + current_cleared_count + 1 == result5.json()[
+    #         'settled_coins']
 
     def test_get_balance(self):
         result = requests.get(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
@@ -178,53 +179,54 @@ class TestRestAPI:
         if result.status_code != 200:
             raise requests.exceptions.HTTPError(result.text)
 
-    def test_concurrent_tx_creation_and_broadcast(self, event_loop):
-        n_txs = 10
-
-        Net.set_to(SVRegTestnet)
-        p2pkh_object = SVRegTestnet.REGTEST_FUNDS_PUBLIC_KEY.to_address()
-
-        P2PKH_OUTPUT = {"value": 10000,
-                        "script_pubkey": p2pkh_object.to_script().to_hex()}
-
-        payload = {
-            "split_value": 20000,
-            "split_count": 100,
-            "password": "test"
-        }
-
-        url = f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/' \
-              f'{self.TEST_WALLET_NAME}/1/txs/split_utxos'
-
-        # 1) split utxos sufficient for n transactions + confirm
-        result = requests.post(url, json=payload)
-        if result.status_code != 200:
-            raise requests.exceptions.HTTPError(result.text)
-
-        result2 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
-                               f'{self.TEST_WALLET_NAME}/1/generate_blocks')
-        if result2.status_code != 200:
-            raise requests.exceptions.HTTPError(result2.text)
-        time.sleep(10)
-
-        # 2) test concurrent transaction creation + broadcast
-        payload2 = {
-            "outputs": [P2PKH_OUTPUT],
-            "password": "test"
-        }
-
-        async def main():
-            async with aiohttp.ClientSession() as session:
-                tasks = [asyncio.create_task(self.create_and_send(session, payload2)) for _ in
-                         range(0, n_txs)]
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            for result in results:
-                error_code = result.get('code')
-                if error_code:
-                    assert False, str(Fault(error_code, result.get('message')))
-
-        event_loop.run_until_complete(main())
+    """Disabled test until websockets are implemented for waiting on tx processing"""
+    # def test_concurrent_tx_creation_and_broadcast(self, event_loop):
+    #     n_txs = 10
+    #
+    #     Net.set_to(SVRegTestnet)
+    #     p2pkh_object = SVRegTestnet.REGTEST_FUNDS_PUBLIC_KEY.to_address()
+    #
+    #     P2PKH_OUTPUT = {"value": 10000,
+    #                     "script_pubkey": p2pkh_object.to_script().to_hex()}
+    #
+    #     payload = {
+    #         "split_value": 20000,
+    #         "split_count": 100,
+    #         "password": "test"
+    #     }
+    #
+    #     url = f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/' \
+    #           f'{self.TEST_WALLET_NAME}/1/txs/split_utxos'
+    #
+    #     # 1) split utxos sufficient for n transactions + confirm
+    #     result = requests.post(url, json=payload)
+    #     if result.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result.text)
+    #
+    #     result2 = requests.post(f'http://127.0.0.1:9999/v1/regtest/dapp/wallets/'
+    #                            f'{self.TEST_WALLET_NAME}/1/generate_blocks')
+    #     if result2.status_code != 200:
+    #         raise requests.exceptions.HTTPError(result2.text)
+    #     time.sleep(10)
+    #
+    #     # 2) test concurrent transaction creation + broadcast
+    #     payload2 = {
+    #         "outputs": [P2PKH_OUTPUT],
+    #         "password": "test"
+    #     }
+    #
+    #     async def main():
+    #         async with aiohttp.ClientSession() as session:
+    #             tasks = [asyncio.create_task(self.create_and_send(session, payload2)) for _ in
+    #                      range(0, n_txs)]
+    #             results = await asyncio.gather(*tasks, return_exceptions=True)
+    #
+    #         for result in results:
+    #             error_code = result.get('code')
+    #             if error_code:
+    #                 assert False, str(Fault(error_code, result.get('message')))
+    #
+    #     event_loop.run_until_complete(main())
 
 """Disabled test until websockets are implemented for waiting on tx processing"""
     # def test_create_and_broadcast_exception_handling(self, event_loop):


### PR DESCRIPTION
… wait on

Otherwise we have to guess at how long it will take for the tx notification to come back with arbitrary sleep times. But Azure pipelines can be unpredictable with processing times.