### PR TITLE
enforce asyncio.WindowsSelectorEventLoopPolicy() for python 3.8+ othe…

### DIFF
--- a/electrumsv/main.py
+++ b/electrumsv/main.py
@@ -26,7 +26,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import asyncio
 import os
 import sys
 import time
@@ -48,6 +48,10 @@ from electrumsv import startup
 from electrumsv.storage import WalletStorage
 from electrumsv.util import json_encode, json_decode, setup_thread_excepthook
 from electrumsv.wallet import Wallet
+
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 # get password routine


### PR DESCRIPTION
…rwise when plugins use `aiodns` for network calls, you get this error: https://github.com/saghul/aiodns/issues/78

```
From cffi callback <function _sock_state_cb at 0x000001C25B3C3430>:
Traceback (most recent call last):
  File "C:\Users\test\.virtualenvs\OneForAll-qYrK1GZO\lib\site-packages\pycares\__init__.py", line 91, in _sock_state_cb
    sock_state_cb(socket_fd, readable, writable)
  File "C:\Users\test\.virtualenvs\OneForAll-qYrK1GZO\lib\site-packages\aiodns\__init__.py", line 104, in _sock_state_cb
    self.loop.add_reader(fd, self._handle_event, fd, READ)
  File "C:\Program Files\Python38\Lib\asyncio\events.py", line 501, in add_reader
    raise NotImplementedError
NotImplementedError
```