### PR TITLE
Fix "sqlite3.OperationalError: ambiguous column name: tx_hash"

### DIFF
--- a/electrumsv/wallet_database/functions.py
+++ b/electrumsv/wallet_database/functions.py
@@ -966,7 +966,7 @@ def read_transaction_value_entries(db: sqlite3.Connection, account_id: int, *,
             "TX.date_created, TX.date_updated "
         "FROM TransactionValues TXV "
         "INNER JOIN Transactions TX ON TX.tx_hash=TXV.tx_hash "
-        "WHERE account_id=? AND tx_hash IN ({}) ")
+        "WHERE account_id=? AND TX.tx_hash IN ({}) ")
     if mask is not None:
         sql += f"AND TX.flags&{mask}!=0 "
     sql += "GROUP BY TXV.tx_hash"

--- a/electrumsv/wallet_database/sqlite_support.py
+++ b/electrumsv/wallet_database/sqlite_support.py
@@ -360,7 +360,7 @@ class SqliteExecutor(concurrent.futures.Executor):
         self._shutdown_event = threading.Event()
         self._active_items = 0
 
-    def submit(self, fn, *args, **kwargs) -> concurrent.futures.Future:
+    def submit(self, fn, *args, **kwargs) -> concurrent.futures.Future:  # type: ignore
         with self._shutdown_lock:
             if self._shutdown:
                 raise RuntimeError('cannot schedule new futures after shutdown')
@@ -371,7 +371,7 @@ class SqliteExecutor(concurrent.futures.Executor):
             self._dispatcher.put(ExecutorItem(future, fn, args, kwargs))
             return future
 
-    def shutdown(self, wait: bool=True) -> None:
+    def shutdown(self, wait: bool=True) -> None:  # type: ignore
         with self._shutdown_lock:
             self._shutdown = True
         if wait:


### PR DESCRIPTION
Just a tiny little fix. I have started picking through your latest refactoring changes to understand it.

When testing the websocket, I get this error:

```
  File "G:\electrumsv_official\examples\applications\restapi\txstatewebsocket.py", line 67, in get
    await self._handle_new_txid_registration(client)
  File "G:\electrumsv_official\examples\applications\restapi\txstatewebsocket.py", line 110, in _handle_new_txid_registration
    tx_entries = client.account.get_local_transaction_entries([tx_hash])
  File "G:\electrumsv_official\electrumsv\wallet.py", line 499, in get_local_transaction_entries
    return self._wallet.read_transaction_value_entries(self._id, tx_hashes=tx_hashes,
  File "G:\electrumsv_official\electrumsv\wallet.py", line 2122, in read_transaction_value_entries
    return db_functions.read_transaction_value_entries(self.get_db_context(), account_id,
  File "G:\electrumsv_official\electrumsv\wallet_database\sqlite_support.py", line 391, in wrapped_call
    return func(db, *args, **kwargs)
  File "G:\electrumsv_official\electrumsv\wallet_database\functions.py", line 973, in read_transaction_value_entries
    return read_rows_by_id(TransactionValueRow, db, sql, [ account_id ], tx_hashes)
  File "G:\electrumsv_official\electrumsv\wallet_database\util.py", line 103, in read_rows_by_id
    cursor = db.execute(sql, params + batch_ids) # type: ignore
sqlite3.OperationalError: ambiguous column name: tx_hash
```

And this change fixes it