### PR TITLE
Features/indexer support exploring

### DIFF
--- a/contrib/scripts/run_mypy.bat
+++ b/contrib/scripts/run_mypy.bat
@@ -1,0 +1,14 @@
+@echo off
+@rem "to specify default python version to 3.9 create/edit ~/AppData/Local/py.ini with [default] set
+@rem to python3=3.9"
+
+REM Get current folder with no trailing slash
+SET ScriptDir=%~dp0
+SET TLD=%ScriptDir%\..\..
+echo %ScriptDir%
+cd %ScriptDir%
+
+py -m pip install types-certifi types-pkg_resources types-python-dateutil types-requests
+py -m pip install git+https://github.com/python-qt-tools/PyQt5-stubs.git@166af25fbe0886f95ef0b1a1b57bbdc893e9144d
+py -m mypy --install-types --non-interactive
+py -m mypy --config=%TLD%\mypy.ini %TLD%\electrumsv

--- a/contrib/scripts/run_pylint.bat
+++ b/contrib/scripts/run_pylint.bat
@@ -1,0 +1,6 @@
+@echo off
+@rem "to specify default python version to 3.9 create/edit ~/AppData/Local/py.ini with [default] set
+@rem to python3=3.9"
+set TLD=%~dp0..\..\electrumsv
+py -m pip install pylint -U
+py -m pylint --rcfile ../../.pylintrc %TLD%

--- a/electrumsv/crypto.py
+++ b/electrumsv/crypto.py
@@ -63,7 +63,7 @@ def strip_PKCS7_padding(data: bytes) -> bytes:
 def aes_encrypt_with_iv(key: bytes, iv: bytes, data: bytes) -> bytes:
     data = append_PKCS7_padding(data)
     if AES:
-        e = AES.new(key, AES.MODE_CBC, iv).encrypt(data)
+        e: bytes = AES.new(key, AES.MODE_CBC, iv).encrypt(data)
     else:
         aes_cbc = pyaes.AESModeOfOperationCBC(key, iv=iv)
         aes = pyaes.Encrypter(aes_cbc, padding=pyaes.PADDING_NONE)

--- a/electrumsv/data/mapi_servers_regtest.json
+++ b/electrumsv/data/mapi_servers_regtest.json
@@ -2,6 +2,7 @@
     {
         "id": 10001,
         "url": "https://127.0.0.1:5051/mapi",
+        "api_key_required": false,
         "static_data_date": "2021-05-13T04:45:05+0000"
     }
 ]

--- a/electrumsv/keystore.py
+++ b/electrumsv/keystore.py
@@ -493,6 +493,7 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
             for x_pubkey in txin.unused_x_pubkeys():
                 if self.is_signature_candidate(x_pubkey):
                     xprv = app_state.credentials.get_indefinite_credential(self._xprv_credential_id)
+                    assert xprv is not None
                     keypairs[x_pubkey] = self._get_private_key_from_xprv(xprv,
                         x_pubkey.derivation_path)
         # Sign

--- a/electrumsv/network_support/mapi.py
+++ b/electrumsv/network_support/mapi.py
@@ -150,7 +150,7 @@ def poll_servers(network: "Network", account: "AbstractAccount") \
     If there is work to be done, a `concurrent.futures.Future` instance is returned. Otherwise
     we return `None`.
     """
-    server_entries: List[Tuple["NewServer", Optional["IndefiniteCredentialId"]]] = []
+    server_entries: List[Tuple["NewServer", "IndefiniteCredentialId"]] = []
     for candidate in network.get_api_servers_for_account(account, NetworkServerType.MERCHANT_API):
         assert candidate.api_server is not None
         assert candidate.credential_id is not None
@@ -169,8 +169,7 @@ async def _poll_servers_async(
             await group.spawn(get_fee_quote, server, credential_id)
 
 
-async def get_fee_quote(server: "NewServer",
-        credential_id: Optional["IndefiniteCredentialId"]) -> None:
+async def get_fee_quote(server: "NewServer", credential_id: "IndefiniteCredentialId") -> None:
     """The last_good and last_try timestamps will be used to include/exclude the mAPI for
     selection"""
     server_state = server.api_key_state[credential_id]
@@ -220,7 +219,7 @@ def validate_json_envelope(json_response: JSONEnvelope) -> None:
 
 
 async def broadcast_transaction(tx: "Transaction", server: "NewServer",
-        credential_id: Optional["IndefiniteCredentialId"]) -> None:
+        credential_id: "IndefiniteCredentialId") -> None:
     server_state = server.api_key_state[credential_id]
     server_state.record_attempt()
 

--- a/electrumsv/types.py
+++ b/electrumsv/types.py
@@ -176,7 +176,7 @@ IndefiniteCredentialId = uuid.UUID
 
 class NetworkServerState(NamedTuple):
     key: ServerAccountKey
-    credential_id: Optional[IndefiniteCredentialId]
+    credential_id: IndefiniteCredentialId
     # MAPI specific, used for JSONEnvelope serialised transaction fee quotes.
     mapi_fee_quote_json: Optional[str] = None
     date_last_try: int = 0


### PR DESCRIPTION
The regtest mAPI server (and others) don't require an api key
- Subsequently, there is no cache entry for CredentialCache._indefinite_credentials.
- This leads to an error in mapi.py:poll_servers at: `assert candidate.credential_id is not None`.
- To fix this, I am exploring the idea of making sure that there is always an entry in the CredentialCache whether or not the server requires Auth. 
- If it does not require auth it will still be assigned a credential_id anyway but the value will be null (indicating that at the time of http requests for this server, it can skip adding the auth headers)

This code is merely an exploratory exercise to assist with discussion about the best way to address this.

With this approach, this section of code can now always returns key_state regardless of if the mAPI server requires auth or not:

    def should_request_fee_quote(self, credential_id: IndefiniteCredentialId) -> bool:
        """
        Work out if we have a valid fee quote, and if not whether we can get one.
        """
        key_state = self.api_key_state[credential_id]