### PR TITLE
Fix #835. When a wallet requires migrating from an older version, it …

### DIFF
--- a/electrumsv/commands.py
+++ b/electrumsv/commands.py
@@ -281,7 +281,10 @@ argparse.ArgumentParser.set_default_subparser = set_default_subparser # type: ig
 # workaround https://bugs.python.org/issue23058
 # see https://github.com/nickstenning/honcho/pull/121
 
-def subparser_call(self: argparse._SubParsersAction, parser: argparse.ArgumentParser,
+# NOTE(AustEcon) Ignore typing due to 'Missing type parameters for generic type
+# "_SubParsersAction"  [type-arg]'
+def subparser_call(self: argparse._SubParsersAction,  # type: ignore[type-arg]
+        parser: argparse.ArgumentParser,
         namespace: Optional[argparse.Namespace], values: List[str],
         option_string: Optional[str]=None) -> None:
     from argparse import ArgumentError, SUPPRESS, _UNRECOGNIZED_ARGS_ATTR

--- a/electrumsv/gui/qt/exception_window.py
+++ b/electrumsv/gui/qt/exception_window.py
@@ -200,7 +200,7 @@ class Exception_Hook(QObject):
     def __init__(self, app: "SVApplication") -> None:
         super().__init__()
         self.app = app
-        sys.excepthook = self.handler
+        sys.excepthook = self.handler  # type: ignore[assignment]
         self.uncaught_signal.connect(self.show)
 
     def handler(self, exc_type: Type[BaseException], exc_value: BaseException,

--- a/electrumsv/gui/qt/wallet_wizard.py
+++ b/electrumsv/gui/qt/wallet_wizard.py
@@ -570,7 +570,8 @@ class ChooseWalletPage(QWizardPage):
         assert entry.path is not None
         password: Optional[str] = None
         wizard = cast(WalletWizard, self.wizard())
-        storage = WalletStorage(entry.path)
+        storage: Optional[WalletStorage] = WalletStorage(entry.path)
+        assert storage is not None
         try:
             password = request_password(self, storage, entry)
             if password is None:
@@ -584,7 +585,7 @@ class ChooseWalletPage(QWizardPage):
                     migration_page = wizard.page(WalletPage.MIGRATE_OLDER_WALLET)
                     migration_page.set_migration_data(entry, storage)
                     # Give the storage object to the migration page, which we are going to.
-                    del storage
+                    storage = None
                     wizard.next()
                 else:
                     assert entry.storage_kind == StorageKind.DATABASE, \

--- a/electrumsv/transaction.py
+++ b/electrumsv/transaction.py
@@ -436,8 +436,8 @@ class XTxInput(TxInput): # type: ignore[misc]
 
     def to_bytes(self) -> bytes:
         if self.x_pubkeys:
-            self.script_sig = create_script_sig(self.script_type, self.threshold, self.x_pubkeys,
-                self.signatures)
+            self.script_sig = create_script_sig(self.script_type,  # type: ignore[misc]
+                self.threshold, self.x_pubkeys, self.signatures)
         return cast(bytes, super().to_bytes())
 
     def signatures_present(self) -> List[bytes]:

--- a/electrumsv/wallet_database/functions.py
+++ b/electrumsv/wallet_database/functions.py
@@ -1551,7 +1551,8 @@ def update_transaction_block_many(db_context: DatabaseContext,
     def _write(db: sqlite3.Connection) -> int:
         nonlocal sql, rows
         cursor = db.executemany(sql, rows)
-        return cast(int, cursor.rowcount)
+        # NOTE(typing) error: Redundant cast to "int"  [redundant-cast]
+        return cast(int, cursor.rowcount)  # type: ignore
     return db_context.post_to_thread(_write)
 
 
@@ -2229,7 +2230,8 @@ class AsynchronousFunctions:
             "SELECT ?, TA.account_id, ?, ? "
             "FROM transaction_accounts TA",
             (tx_hash, tx_hash, tx_hash, timestamp, timestamp))
-        return cast(int, cursor.rowcount)
+        # NOTE(typing) error: Redundant cast to "int"  [redundant-cast]
+        return cast(int, cursor.rowcount)  # type: ignore
 
     def _reconcile_transaction_output_spends(self, db: sqlite3.Connection, tx_hash: bytes) -> bool:
         """


### PR DESCRIPTION
…e initially loaded storage instance

- This results in a "local variable 'storage' referenced before assignment" error in the finally clause.
- Setting storage = None after the delete gives the finally clause something to reference and stops the error.

https://github.com/electrumsv/electrumsv/issues/835