### PR TITLE
HeaderSV API Integration

### DIFF
--- a/electrumsv/app_state.py
+++ b/electrumsv/app_state.py
@@ -211,6 +211,7 @@ class AppStateProxy(object):
             fiat_text = ''
         return bitcoin_text, fiat_text
 
+    # TODO(1.4.0) Replace with non-electrumx equivalent
     def electrumx_message_size_limit(self) -> int:
         return max(0,
             self.config.get_explicit_type(int, 'electrumx_message_size_limit',

--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -386,9 +386,8 @@ class NetworkEventNames:
 
 
 class NetworkServerType(IntEnum):
-    ELECTRUMX = 1
-    MERCHANT_API = 2
-    GENERAL = 3
+    MERCHANT_API = 1
+    GENERAL = 2
 
 
 API_SERVER_TYPES = { NetworkServerType.MERCHANT_API, NetworkServerType.GENERAL }
@@ -397,15 +396,15 @@ API_SERVER_TYPES = { NetworkServerType.MERCHANT_API, NetworkServerType.GENERAL }
 class ServerCapability(IntEnum):
     TRANSACTION_BROADCAST = 1
     FEE_QUOTE = 2
-    # The ElectrumX script hash notification API.
-    SCRIPTHASH_HISTORY = 3
-    MERKLE_PROOF_REQUEST = 4
-    MERKLE_PROOF_NOTIFICATION = 5
-    # The "General API" restoration sub-API.
+    MERKLE_PROOF_NOTIFICATION = 3
+    HEADERS = 4
+    PEER_CHANNELS = 5
+
+    # The following are for the NetworkServerType.GENERAL sub-API for restoration and
+    # fetching of arbitrary transactions and merkle proofs
     RESTORATION = 6
-    TRANSACTION_REQUEST = 7
-    HEADERS = 8
-    PEER_CHANNELS = 9
+    MERKLE_PROOF_REQUEST = 7
+    TRANSACTION_REQUEST = 8
 
 
 PREFIX_ASM_SCRIPT = "asm:"

--- a/electrumsv/gui/qt/blockchain_scan_dialog.py
+++ b/electrumsv/gui/qt/blockchain_scan_dialog.py
@@ -71,7 +71,7 @@ from ...blockchain_scanner import AdvancedSettings, DEFAULT_GAP_LIMITS, Blockcha
     SearchKeyEnumerator
 from ...exceptions import ServerConnectionError
 from ...i18n import _
-from ...network_support.general_api import FilterResponseIncompleteError, FilterResponseInvalidError
+from ...network_support.exceptions import FilterResponseIncompleteError, FilterResponseInvalidError
 from ...logs import logs
 from ...wallet import Wallet
 from ...wallet_database.types import TransactionLinkState

--- a/electrumsv/gui/qt/network_dialog.py
+++ b/electrumsv/gui/qt/network_dialog.py
@@ -28,15 +28,11 @@ import dataclasses
 import datetime
 import enum
 from functools import partial
-import socket
-from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, Sequence, \
-    TYPE_CHECKING, Tuple, Union
-import urllib.parse
+from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, \
+    TYPE_CHECKING, Tuple
 
-from aiorpcx import NetAddress
-from bitcoinx import Chain, hash_to_hex_str
-from PyQt5.QtCore import pyqtSignal, QAbstractItemModel, QModelIndex, QObject, QPoint, Qt, \
-    QThread, QTimer
+from PyQt5.QtCore import pyqtSignal, QAbstractItemModel, QModelIndex, QObject, Qt, \
+    QTimer
 from PyQt5.QtGui import QBrush, QCloseEvent, QColor, QContextMenuEvent, QIcon, QKeyEvent, \
     QPixmap, QValidator
 from PyQt5.QtWidgets import QAbstractItemView, QCheckBox, QComboBox, QDialog, \
@@ -51,17 +47,16 @@ from ...crypto import pw_decode, pw_encode
 from ...i18n import _
 from ...logs import logs
 from ...wallet import Wallet
-from ...network import Network, SVServerKey, SVUserAuth, SVProxy, SVSession, SVServer
+from ...network import Network
 from ...network_support.api_server import APIServerDefinition, CapabilitySupport, NewServer, \
     SERVER_CAPABILITIES
 from ...types import ServerAccountKey
 from ...util.network import DEFAULT_SCHEMES, UrlValidationError, validate_url
 from ...wallet_database.types import NetworkServerRow, NetworkServerAccountRow
 
-from .password_dialog import PasswordLineEdit
 from .table_widgets import TableTopButtonLayout
 from .util import Buttons, CloseButton, ExpandableSection, FormSectionWidget,  \
-    HelpButton, HelpDialogButton, icon_path, MessageBox, read_QIcon, WindowModalDialog
+    HelpDialogButton, icon_path, MessageBox, read_QIcon, WindowModalDialog
 
 
 if TYPE_CHECKING:
@@ -77,13 +72,11 @@ logger = logs.get_logger("network-ui")
 
 # These are display ordered for the combo box.
 SERVER_TYPE_ENTRIES = [
-    NetworkServerType.ELECTRUMX,
     NetworkServerType.GENERAL,
     NetworkServerType.MERCHANT_API,
 ]
 
 SERVER_TYPE_LABELS = {
-    NetworkServerType.ELECTRUMX: _("ElectrumX"),
     NetworkServerType.GENERAL: _("General"),
     NetworkServerType.MERCHANT_API: _("MAPI"),
 }
@@ -109,7 +102,6 @@ class ServerListEntry(NamedTuple):
     can_configure_wallet_access: bool = False
     api_key_supported: bool = False
     api_key_required: bool = False
-    data_electrumx: Optional[SVServer] = None
     data_api: Optional[NewServer] = None
 
 
@@ -125,234 +117,223 @@ PASSWORD_REQUEST_TEXT = _("You have associated a new API key with the wallet '{}
     "encrypt the API key for storage in this wallet, you will need to provide it's password.")
 
 
-def url_to_server_key(url: str) -> SVServerKey:
-    """
-    Convert a URL to a server key.
+# TODO(1.4.0) - modify to indicate current chain tips (a representation of the HeaderSV chain tips)
+#  and which chain this wallet is on which at least in the near term will be
+#  coupled to the indexer which always gives a materialized view of the longest chain.
+# class NodesListColumn(enum.IntEnum):
+#     SERVER = 0
+#     HEIGHT = 1
+#
+#
+# class NodesListWidget(QTreeWidget):
+#
+#     def __init__(self, parent: 'BlockchainTab', network: Network) -> None:
+#         super().__init__()
+#         self._network = network
+#         self._parent_tab = parent
+#         self.setHeaderLabels([ _('Connected server'), _('Height') ])
+#         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+#         self.customContextMenuRequested.connect(self.create_menu)
+#
+#         self._connected_pixmap = QPixmap(icon_path("icons8-data-transfer-80-blue.png")
+#             ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
+#         self._warning_pixmap = QPixmap(icon_path("icons8-error-48-ui.png")
+#             ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
+#         self._connected_icon = QIcon(self._connected_pixmap)
+#         self._lock_pixmap = QPixmap(icon_path("icons8-lock-windows.svg")
+#             ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
+#
+#     def create_menu(self, position: QPoint) -> None:
+#         item = self.currentItem()
+#         if not item:
+#             return
+#         server = item.data(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole)
+#         if not server:
+#             return
+#
+#         def use_as_server(auto_connect: bool) -> None:
+#             try:
+#                 self._parent_tab._parent.follow_server(server, auto_connect)
+#             except Exception as e:
+#                 MessageBox.show_error(str(e))
+#
+#         menu = QMenu()
+#         action = menu.addAction(_("Use as main server"), partial(use_as_server, True))
+#         action.setEnabled(server != self._network.main_server)
+#         if self._network.auto_connect() or server != self._network.main_server:
+#             action = menu.addAction(_("Lock as main server"), partial(use_as_server, False))
+#             action.setEnabled(app_state.config.is_modifiable('auto_connect'))
+#         else:
+#             action = menu.addAction(_("Unlock as main server"), partial(use_as_server, True))
+#             action.setEnabled(app_state.config.is_modifiable('auto_connect') and \
+#                 server == self._network.main_server)
+#         menu.exec_(self.viewport().mapToGlobal(position))
+#
+#     def keyPressEvent(self, event: QKeyEvent) -> None:
+#         if event.key() in [ Qt.Key.Key_F2, Qt.Key.Key_Return ]:
+#             self.on_activated(self.currentItem(), self.currentColumn())
+#         else:
+#             QTreeWidget.keyPressEvent(self, event)
+#
+#     def on_activated(self, item: QTreeWidgetItem, _column: int) -> None:
+#         # on 'enter' we show the menu
+#         pt = self.visualItemRect(item).bottomLeft()
+#         pt.setX(50)
+#         self.customContextMenuRequested.emit(pt)
+#
+#     def chain_name(self, chain: Chain, our_chain: Chain) -> str:
+#         if chain is our_chain:
+#             return 'our_chain'
+#
+#         _chain, common_height = our_chain.common_chain_and_height(chain)
+#         fork_height = common_height + 1
+#         assert app_state.headers is not None
+#         header = app_state.headers.header_at_height(chain, fork_height)
+#         prefix = hash_to_hex_str(header.hash).lstrip('00')[0:10]
+#         return f'{prefix}@{fork_height}'
+#
+#     def update(self) -> None: # type: ignore[override]
+#         assert self._network.main_server is not None
+#
+#         self.clear()
+#
+#         chains = self._network.sessions_by_chain()
+#         chain_items = list(chains.items())
+#         host_counts: Dict[str, int] = {}
+#         for chain, sessions in chain_items:
+#             # If someone is connected to two nodes on the same server, indicate the difference.
+#             for i, session in enumerate(sessions):
+#                 host_counts[session.server.host] = host_counts.get(session.server.host, 0) + 1
+#
+#         tree_item: Union[NodesListWidget, QTreeWidgetItem]
+#         our_chain = self._network.chain()
+#         for chain, sessions in chain_items:
+#             if len(chains) > 1:
+#                 assert our_chain is not None
+#                 name = self.chain_name(chain, our_chain)
+#                 tree_item = QTreeWidgetItem([name, '%d' % chain.height])
+#                 tree_item.setData(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole, None)
+#             else:
+#                 tree_item = self
+#             for session in sessions:
+#                 assert session.tip is not None
+#                 extra_name = ""
+#                 if host_counts[session.server.host] > 1:
+#                     extra_name = f" (port: {session.server.port})"
+#                 extra_name += ' (main server)' if session.server is self._network.main_server \
+#                     else ''
+#                 item = QTreeWidgetItem([session.server.host + extra_name,
+#                     str(session.tip.height)])
+#                 item.setIcon(NodesListColumn.SERVER, self._connected_icon)
+#                 if session.server.protocol == "t":
+#                     item.setToolTip(NodesListColumn.SERVER, _("Unencrypted"))
+#                 else:
+#                     item.setToolTip(NodesListColumn.SERVER, _("Encrypted / SSL"))
+#                 item.setData(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole, session.server)
+#                 if isinstance(tree_item, NodesListWidget):
+#                     tree_item.addTopLevelItem(item)
+#                 else:
+#                     tree_item.addChild(item)
+#             if len(chains) > 1:
+#                 assert isinstance(tree_item, QTreeWidgetItem)
+#                 self.addTopLevelItem(tree_item)
+#                 tree_item.setExpanded(True)
+#
+#             height_str = "%d "%(self._network.get_local_height()) + _('blocks')
+#             self._parent_tab.height_label.setText(height_str)
+#             n = len(self._network.sessions)
+#             if n == 0:
+#                 status = _("Not connected")
+#             elif n == 1:
+#                 status = _("Connected to {:d} server.").format(n)
+#             else:
+#                 status = _("Connected to {:d} servers.").format(n)
+#             self._parent_tab.status_label.setText(status)
+#
+#             chains2 = self._network.sessions_by_chain().keys()
+#             if len(chains2) > 1:
+#                 our_chain = self._network.chain()
+#                 assert our_chain is not None
+#                 heights = set()
+#                 for chain in chains2:
+#                     if chain != our_chain:
+#                         _chain, common_height = our_chain.common_chain_and_height(chain)
+#                         heights.add(common_height + 1)
+#                 msg = _('Chain split detected at height(s) {}\n').format(
+#                     ','.join(f'{height:,d}' for height in sorted(heights)))
+#             else:
+#                 msg = ''
+#             self._parent_tab.split_label.setText(msg)
+#             self._parent_tab.server_label.setText(self._network.main_server.host)
+#
+#             # Ordered pixmaps, show only as many as applicable. Probably a better way to do this.
+#             pixmaps: List[Tuple[Optional[QPixmap], str]] = []
+#             if not self._network.auto_connect():
+#                 pixmaps.append((self._lock_pixmap,
+#                     _("This server is locked into place as the permanent main server.")))
+#             if self._network.main_server.state.last_good <
+#                   self._network.main_server.state.last_try:
+#                 pixmaps.append((self._warning_pixmap,
+#                     _("This server is not known to be up to date.")))
+#
+#             while len(pixmaps) < 2:
+#                 pixmaps.append((None, ''))
+#
+#             if pixmaps[0][0] is None:
+#                 self._parent_tab.server_label_icon1.clear()
+#             else:
+#                 self._parent_tab.server_label_icon1.setPixmap(pixmaps[0][0])
+#                 self._parent_tab.server_label_icon1.setToolTip(pixmaps[0][1])
+#             if pixmaps[1][0] is None:
+#                 self._parent_tab.server_label_icon2.clear()
+#             else:
+#                 self._parent_tab.server_label_icon2.setPixmap(pixmaps[1][0])
+#                 self._parent_tab.server_label_icon2.setToolTip(pixmaps[1][1])
+#
+#         h = self.header()
+#         h.setStretchLastSection(False)
+#         h.setSectionResizeMode(NodesListColumn.SERVER, QHeaderView.ResizeMode.Stretch)
+#         h.setSectionResizeMode(NodesListColumn.HEIGHT, QHeaderView.ResizeMode.ResizeToContents)
+#
 
-    This does not do validation in any way, shape or form. It is assumed before we got to this
-    point there was some kind of validation that passed.
-    """
-    result = urllib.parse.urlparse(url)
-    protocol = "s" if result.scheme.startswith("ssl") else "t"
-    if ":" in result.netloc:
-        host, port_str = result.netloc.split(":")
-        port = int(port_str)
-    else:
-        host = result.netloc
-        port = 50002 if protocol == "s" else 50001
-    return SVServerKey(host, port, protocol)
-
-
-class NodesListColumn(enum.IntEnum):
-    SERVER = 0
-    HEIGHT = 1
-
-
-class NodesListWidget(QTreeWidget):
-
-    def __init__(self, parent: 'BlockchainTab', network: Network) -> None:
-        super().__init__()
-        self._network = network
-        self._parent_tab = parent
-        self.setHeaderLabels([ _('Connected server'), _('Height') ])
-        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.customContextMenuRequested.connect(self.create_menu)
-
-        self._connected_pixmap = QPixmap(icon_path("icons8-data-transfer-80-blue.png")
-            ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
-        self._warning_pixmap = QPixmap(icon_path("icons8-error-48-ui.png")
-            ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
-        self._connected_icon = QIcon(self._connected_pixmap)
-        self._lock_pixmap = QPixmap(icon_path("icons8-lock-windows.svg")
-            ).scaledToWidth(16, Qt.TransformationMode.SmoothTransformation)
-
-    def create_menu(self, position: QPoint) -> None:
-        item = self.currentItem()
-        if not item:
-            return
-        server = item.data(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole)
-        if not server:
-            return
-
-        def use_as_server(auto_connect: bool) -> None:
-            try:
-                self._parent_tab._parent.follow_server(server, auto_connect)
-            except Exception as e:
-                MessageBox.show_error(str(e))
-
-        menu = QMenu()
-        action = menu.addAction(_("Use as main server"), partial(use_as_server, True))
-        action.setEnabled(server != self._network.main_server)
-        if self._network.auto_connect() or server != self._network.main_server:
-            action = menu.addAction(_("Lock as main server"), partial(use_as_server, False))
-            action.setEnabled(app_state.config.is_modifiable('auto_connect'))
-        else:
-            action = menu.addAction(_("Unlock as main server"), partial(use_as_server, True))
-            action.setEnabled(app_state.config.is_modifiable('auto_connect') and \
-                server == self._network.main_server)
-        menu.exec_(self.viewport().mapToGlobal(position))
-
-    def keyPressEvent(self, event: QKeyEvent) -> None:
-        if event.key() in [ Qt.Key.Key_F2, Qt.Key.Key_Return ]:
-            self.on_activated(self.currentItem(), self.currentColumn())
-        else:
-            QTreeWidget.keyPressEvent(self, event)
-
-    def on_activated(self, item: QTreeWidgetItem, _column: int) -> None:
-        # on 'enter' we show the menu
-        pt = self.visualItemRect(item).bottomLeft()
-        pt.setX(50)
-        self.customContextMenuRequested.emit(pt)
-
-    def chain_name(self, chain: Chain, our_chain: Chain) -> str:
-        if chain is our_chain:
-            return 'our_chain'
-
-        _chain, common_height = our_chain.common_chain_and_height(chain)
-        fork_height = common_height + 1
-        assert app_state.headers is not None
-        header = app_state.headers.header_at_height(chain, fork_height)
-        prefix = hash_to_hex_str(header.hash).lstrip('00')[0:10]
-        return f'{prefix}@{fork_height}'
-
-    def update(self) -> None: # type: ignore[override]
-        assert self._network.main_server is not None
-
-        self.clear()
-
-        chains = self._network.sessions_by_chain()
-        chain_items = list(chains.items())
-        host_counts: Dict[str, int] = {}
-        for chain, sessions in chain_items:
-            # If someone is connected to two nodes on the same server, indicate the difference.
-            for i, session in enumerate(sessions):
-                host_counts[session.server.host] = host_counts.get(session.server.host, 0) + 1
-
-        tree_item: Union[NodesListWidget, QTreeWidgetItem]
-        our_chain = self._network.chain()
-        for chain, sessions in chain_items:
-            if len(chains) > 1:
-                assert our_chain is not None
-                name = self.chain_name(chain, our_chain)
-                tree_item = QTreeWidgetItem([name, '%d' % chain.height])
-                tree_item.setData(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole, None)
-            else:
-                tree_item = self
-            for session in sessions:
-                assert session.tip is not None
-                extra_name = ""
-                if host_counts[session.server.host] > 1:
-                    extra_name = f" (port: {session.server.port})"
-                extra_name += ' (main server)' if session.server is self._network.main_server \
-                    else ''
-                item = QTreeWidgetItem([session.server.host + extra_name,
-                    str(session.tip.height)])
-                item.setIcon(NodesListColumn.SERVER, self._connected_icon)
-                if session.server.protocol == "t":
-                    item.setToolTip(NodesListColumn.SERVER, _("Unencrypted"))
-                else:
-                    item.setToolTip(NodesListColumn.SERVER, _("Encrypted / SSL"))
-                item.setData(NodesListColumn.SERVER, Qt.ItemDataRole.UserRole, session.server)
-                if isinstance(tree_item, NodesListWidget):
-                    tree_item.addTopLevelItem(item)
-                else:
-                    tree_item.addChild(item)
-            if len(chains) > 1:
-                assert isinstance(tree_item, QTreeWidgetItem)
-                self.addTopLevelItem(tree_item)
-                tree_item.setExpanded(True)
-
-            height_str = "%d "%(self._network.get_local_height()) + _('blocks')
-            self._parent_tab.height_label.setText(height_str)
-            n = len(self._network.sessions)
-            if n == 0:
-                status = _("Not connected")
-            elif n == 1:
-                status = _("Connected to {:d} server.").format(n)
-            else:
-                status = _("Connected to {:d} servers.").format(n)
-            self._parent_tab.status_label.setText(status)
-
-            chains2 = self._network.sessions_by_chain().keys()
-            if len(chains2) > 1:
-                our_chain = self._network.chain()
-                assert our_chain is not None
-                heights = set()
-                for chain in chains2:
-                    if chain != our_chain:
-                        _chain, common_height = our_chain.common_chain_and_height(chain)
-                        heights.add(common_height + 1)
-                msg = _('Chain split detected at height(s) {}\n').format(
-                    ','.join(f'{height:,d}' for height in sorted(heights)))
-            else:
-                msg = ''
-            self._parent_tab.split_label.setText(msg)
-            self._parent_tab.server_label.setText(self._network.main_server.host)
-
-            # Ordered pixmaps, show only as many as applicable. Probably a better way to do this.
-            pixmaps: List[Tuple[Optional[QPixmap], str]] = []
-            if not self._network.auto_connect():
-                pixmaps.append((self._lock_pixmap,
-                    _("This server is locked into place as the permanent main server.")))
-            if self._network.main_server.state.last_good < self._network.main_server.state.last_try:
-                pixmaps.append((self._warning_pixmap,
-                    _("This server is not known to be up to date.")))
-
-            while len(pixmaps) < 2:
-                pixmaps.append((None, ''))
-
-            if pixmaps[0][0] is None:
-                self._parent_tab.server_label_icon1.clear()
-            else:
-                self._parent_tab.server_label_icon1.setPixmap(pixmaps[0][0])
-                self._parent_tab.server_label_icon1.setToolTip(pixmaps[0][1])
-            if pixmaps[1][0] is None:
-                self._parent_tab.server_label_icon2.clear()
-            else:
-                self._parent_tab.server_label_icon2.setPixmap(pixmaps[1][0])
-                self._parent_tab.server_label_icon2.setToolTip(pixmaps[1][1])
-
-        h = self.header()
-        h.setStretchLastSection(False)
-        h.setSectionResizeMode(NodesListColumn.SERVER, QHeaderView.ResizeMode.Stretch)
-        h.setSectionResizeMode(NodesListColumn.HEIGHT, QHeaderView.ResizeMode.ResizeToContents)
-
-
-class BlockchainTab(QWidget):
-
-    def __init__(self, parent: "NetworkTabsLayout", network: Network) -> None:
-        super().__init__()
-        self._parent = parent
-        self._network = network
-
-        blockchain_layout = QVBoxLayout(self)
-
-        form = FormSectionWidget()
-        self.status_label = QLabel(_("No connections yet."))
-        form.add_row(_('Status'), self.status_label)
-        self.server_label = QLabel()
-        self.server_label_icon1 = QLabel()
-        self.server_label_icon2 = QLabel()
-        server_label_layout = QHBoxLayout()
-        server_label_layout.addWidget(self.server_label)
-        server_label_layout.addSpacing(4)
-        server_label_layout.addWidget(self.server_label_icon1)
-        server_label_layout.addSpacing(4)
-        server_label_layout.addWidget(self.server_label_icon2)
-        server_label_layout.addStretch(1)
-        form.add_row(_('Main server'), server_label_layout)
-        self.height_label = QLabel('')
-        form.add_row(_('Blockchain'), self.height_label)
-
-        blockchain_layout.addWidget(form)
-
-        self.split_label = QLabel('')
-        form.add_row(QLabel(""), self.split_label)
-
-        self.nodes_list_widget = NodesListWidget(self, self._network)
-        blockchain_layout.addWidget(self.nodes_list_widget)
-        blockchain_layout.addStretch(1)
-        self.nodes_list_widget.update()
+# TODO(1.4.0) - modify to indicate current chain tips (a representation of the HeaderSV chain tips)
+#  and which chain this wallet is on which at least in the near term will be
+#  coupled to the indexer which always gives a materialized view of the longest chain.
+# class BlockchainTab(QWidget):
+#
+#     def __init__(self, parent: "NetworkTabsLayout", network: Network) -> None:
+#         super().__init__()
+#         self._parent = parent
+#         self._network = network
+#
+#         blockchain_layout = QVBoxLayout(self)
+#
+#         form = FormSectionWidget()
+#         self.status_label = QLabel(_("No connections yet."))
+#         form.add_row(_('Status'), self.status_label)
+#         self.server_label = QLabel()
+#         self.server_label_icon1 = QLabel()
+#         self.server_label_icon2 = QLabel()
+#         server_label_layout = QHBoxLayout()
+#         server_label_layout.addWidget(self.server_label)
+#         server_label_layout.addSpacing(4)
+#         server_label_layout.addWidget(self.server_label_icon1)
+#         server_label_layout.addSpacing(4)
+#         server_label_layout.addWidget(self.server_label_icon2)
+#         server_label_layout.addStretch(1)
+#         form.add_row(_('Main server'), server_label_layout)
+#         self.height_label = QLabel('')
+#         form.add_row(_('Blockchain'), self.height_label)
+#
+#         blockchain_layout.addWidget(form)
+#
+#         self.split_label = QLabel('')
+#         form.add_row(QLabel(""), self.split_label)
+#
+#         self.nodes_list_widget = NodesListWidget(self, self._network)
+#         blockchain_layout.addWidget(self.nodes_list_widget)
+#         blockchain_layout.addStretch(1)
+#         self.nodes_list_widget.update()
 
 
 @dataclasses.dataclass
@@ -433,10 +414,6 @@ class EditServerDialog(WindowModalDialog):
         self._server_row_by_wallet_path: Dict[str, NetworkServerRow] = {}
         self._account_rows_by_wallet_path: Dict[str, List[NetworkServerAccountRow]] = {}
 
-        server_type_schemes: Optional[set[str]] = None
-        if entry.server_type == NetworkServerType.ELECTRUMX:
-            server_type_schemes = {"ssl", "tcp"}
-
         self._vbox = QVBoxLayout(self)
 
         # NOTE(server-edit-limitations) We do not allow changing either server type or url for
@@ -485,6 +462,7 @@ class EditServerDialog(WindowModalDialog):
         self._server_url_edit.setText(entry.url)
         default_edit_palette = self._server_url_edit.palette()
         default_base_brush = default_edit_palette.brush(default_edit_palette.Base)
+        server_type_schemes: Optional[set[str]] = None
         self._url_validator = URLValidator(schemes=server_type_schemes)
         self._server_url_edit.setValidator(self._url_validator)
         self._server_url_edit.textChanged.connect(
@@ -852,16 +830,7 @@ class EditServerDialog(WindowModalDialog):
         # given URL regardless of the case used. However, if we are editing the server that was
         # already using the given URL we allow it to be saved and consider it valid.
         server_type = self._get_server_type()
-        if server_type == NetworkServerType.ELECTRUMX:
-            assert self._entry.data_electrumx is not None
-            electrumx_server_key = url_to_server_key(url)
-            if electrumx_server_key in SVServer.all_servers:
-                # If we are editing this server, allow it to save/update with the same URL.
-                if self._is_edit_mode and self._entry.data_electrumx.key() == electrumx_server_key:
-                    pass
-                else:
-                    return _("This URL is already in use.")
-        elif server_type in API_SERVER_TYPES:
+        if server_type in API_SERVER_TYPES:
             existing_urls = set(server_key.url.lower() \
                 for server_key in self._network.get_api_servers())
             if url.lower() in existing_urls:
@@ -916,23 +885,10 @@ class EditServerDialog(WindowModalDialog):
         server_type = self._get_server_type()
         server_url = self._server_url_edit.text().strip()
 
-        if server_type == NetworkServerType.ELECTRUMX:
-            self._save_electrumx_server(server_url)
-        elif server_type in API_SERVER_TYPES:
+        if server_type in API_SERVER_TYPES:
             self._save_api_server(server_type, server_url)
         else:
             raise NotImplementedError(f"Unsupported server type {server_type}")
-
-    def _save_electrumx_server(self, server_url: str) -> None:
-        if self._is_edit_mode:
-            updated_server_key = url_to_server_key(server_url)
-            assert self._entry is not None
-            existing_server_key = url_to_server_key(self._entry.url)
-            self._network.update_electrumx_server(existing_server_key, updated_server_key)
-        else:
-            server_key = url_to_server_key(server_url)
-            self._network.add_electrumx_server(server_key)
-        self.accept()
 
     def _save_api_server(self, server_type: NetworkServerType, server_url: str) -> None:
         wallet: Optional[Wallet]
@@ -1129,13 +1085,7 @@ class EditServerDialog(WindowModalDialog):
         server_type = self._get_server_type()
 
         validator = cast(URLValidator, self._server_url_edit.validator())
-        if server_type == NetworkServerType.ELECTRUMX:
-            validator.set_schemes({"ssl", "tcp"})
-            self._entry = self._entry._replace(
-                server_type=server_type,
-                can_configure_wallet_access=False,
-                api_key_supported=False)
-        elif server_type in API_SERVER_TYPES:
+        if server_type in API_SERVER_TYPES:
             validator.set_schemes(DEFAULT_SCHEMES)
             self._entry = self._entry._replace(
                 server_type=server_type,
@@ -1153,15 +1103,11 @@ class EditServerDialog(WindowModalDialog):
         """
         Update the form contents for the current server type value.
         """
-        server_capabilities: List[CapabilitySupport] = []
-
         server_type = self._get_server_type()
-        server_capabilities = SERVER_CAPABILITIES[server_type]
+        server_capabilities: List[CapabilitySupport] = SERVER_CAPABILITIES[server_type]
         assert len(server_capabilities)
         if server_type in API_SERVER_TYPES:
             self._url_validator.set_criteria(allow_path=True)
-        elif server_type == NetworkServerType.ELECTRUMX:
-            self._url_validator.set_criteria(allow_path=False)
         else:
             raise NotImplementedError(f"Unsupported server type {server_type}")
 
@@ -1318,9 +1264,10 @@ class ServersListWidget(QTableWidget):
 
             is_connected = False
             considered_good = False
-            if list_entry.data_electrumx is not None:
-                is_connected = self._is_server_healthy(list_entry.data_electrumx,
-                    self._network.sessions)
+            # TODO (1.4.0) Maybe this is relevant to non ElectrumX server types?
+            # if list_entry.data_electrumx is not None:
+            #     is_connected = self._is_server_healthy(list_entry.data_electrumx,
+            #         self._network.sessions)
 
             if self._network.is_server_disabled(list_entry.url, list_entry.server_type):
                 tooltip_text = _("This server has been configured to be disabled by the user.")
@@ -1364,12 +1311,6 @@ class ServersListWidget(QTableWidget):
             self.setItem(row_index, 1, item_1)
 
             item_2 = SortableServerQTableWidgetItem()
-            if list_entry.server_type == NetworkServerType.ELECTRUMX:
-                if list_entry.data_electrumx == self._network.main_server and \
-                        not self._network.auto_connect():
-                    item_2.setIcon(self._lock_icon)
-                    item_2.setToolTip(
-                        _("This server is locked into place as the permanent main server."))
             self.setItem(row_index, 2, item_2)
 
             item_3 = SortableServerQTableWidgetItem()
@@ -1388,30 +1329,6 @@ class ServersListWidget(QTableWidget):
         hh.setSectionResizeMode(1, QHeaderView.Stretch)
         hh.setSectionResizeMode(2, QHeaderView.ResizeToContents)
         hh.setSectionResizeMode(3, QHeaderView.ResizeToContents)
-
-    @staticmethod
-    def _is_server_healthy(server: SVServer, sessions: Sequence[SVSession]) -> bool:
-        """Sessions only include currently active SVSessions, hence the for loop and
-        matching pattern - this only applies to ElectrumX type servers"""
-        if not sessions:
-            return False
-
-        for session in sessions:
-            if session.server == server:
-                break
-        else:
-            return False  # The server is unable to connect - there is no SVSession for it
-
-        if session.tip is None:
-            return False
-
-        max_tip_height = max([session.tip.height if session.tip is not None else 0
-            for session in sessions])
-        is_more_than_two_blocks_behind = max_tip_height > session.tip.height + 2
-        if server.state.last_good >= server.state.last_try and not is_more_than_two_blocks_behind:
-            return True
-
-        return False
 
     def _get_selected_entry(self) -> ServerListEntry:
         items = self.selectedItems()
@@ -1450,28 +1367,16 @@ class ServersListWidget(QTableWidget):
             return
         entry = cast(ServerListEntry, items[0].data(Roles.ITEM_DATA))
 
-        def use_as_server(auto_connect: bool) -> None:
-            nonlocal entry
-            assert entry.data_electrumx is not None
-            try:
-                self._parent_tab._parent.follow_server(entry.data_electrumx, auto_connect)
-            except Exception as e:
-                MessageBox.show_error(str(e))
+        # def use_as_server(auto_connect: bool) -> None:
+        #     nonlocal entry
+        #     assert entry.data_electrumx is not None
+        #     try:
+        #         self._parent_tab._parent.follow_server(entry.data_electrumx, auto_connect)
+        #     except Exception as e:
+        #         MessageBox.show_error(str(e))
 
         menu = QMenu(self)
         details_action = menu.addAction("Details")
-
-        if entry.data_electrumx is not None:
-            is_main_server = entry.data_electrumx == self._network.main_server
-            action = menu.addAction(_("Use as main server"), partial(use_as_server, True))
-            action.setEnabled(not is_main_server)
-            if self._network.auto_connect() or not is_main_server:
-                action = menu.addAction(_("Lock as main server"), partial(use_as_server, False))
-                action.setEnabled(app_state.config.is_modifiable('auto_connect'))
-            else:
-                action = menu.addAction(_("Unlock as main server"), partial(use_as_server, True))
-                action.setEnabled(app_state.config.is_modifiable('auto_connect') and \
-                    is_main_server)
 
         menu.addAction(_("Delete server"), partial(self._on_menu_delete_server, entry))
 
@@ -1487,10 +1392,7 @@ class ServersListWidget(QTableWidget):
                 self):
             return
 
-        if entry.data_electrumx is not None:
-            callback = self.server_disconnected_signal.emit
-            self._network.delete_electrumx_server(entry.data_electrumx.key(), callback)
-        elif entry.data_api is not None:
+        if entry.data_api is not None:
             # Delete this server from any loaded wallets. We do not know if it is actually used
             # by any of these servers but we can do the delete and it should flush out any
             # actual uses.
@@ -1544,17 +1446,6 @@ class ServersTab(QWidget):
     def update_servers(self) -> None:
         items: List[ServerListEntry] = []
 
-        # Add ElectrumX servers
-        for server in self._network.get_servers():
-            proto_prefix = f"tcp://" if server.protocol == "t" else "ssl://"
-            url = proto_prefix + f"{server.host}:{server.port}"
-            items.append(ServerListEntry(
-                NetworkServerType.ELECTRUMX,
-                url,
-                last_try=server.state.last_try,
-                last_good=server.state.last_good,
-                data_electrumx=server))
-
         # Add API server items.
         for server_key, api_server in self._network.get_api_servers().items():
             # TODO(API) If the server is not an application default and even if it is, there
@@ -1588,7 +1479,8 @@ class ServersTab(QWidget):
                 data_api=api_server))
 
         self._server_list.update_list(items)
-        self._parent._blockchain_tab.nodes_list_widget.update()
+        # TODO(1.4.0) - replace with HeaderSV chain tips and local chain state this wallet follows
+        # self._parent._blockchain_tab.nodes_list_widget.update()
         self._enable_set_broadcast_service()
 
     def _enable_set_broadcast_service(self) -> None:
@@ -1598,192 +1490,31 @@ class ServersTab(QWidget):
             self._server_list.setEnabled(False)
 
 
-class ProxyTab(QWidget):
-
-    def __init__(self, network: Network) -> None:
-        super().__init__()
-
-        self._network = network
-
-        grid = QGridLayout(self)
-        grid.setSpacing(8)
-
-        # proxy setting
-        self._proxy_checkbox = QCheckBox(_('Use proxy'))
-        self._proxy_checkbox.clicked.connect(self._check_disable_proxy)
-        self._proxy_checkbox.clicked.connect(self._set_proxy)
-
-        self._proxy_mode_combo = QComboBox()
-        self._proxy_mode_combo.addItems(list(SVProxy.kinds))
-        self._proxy_host_edit = QLineEdit()
-        self._proxy_host_edit.setFixedWidth(200)
-        self._proxy_port_edit = QLineEdit()
-        self._proxy_port_edit.setFixedWidth(100)
-        self._proxy_username_edit = QLineEdit()
-        self._proxy_username_edit.setPlaceholderText(_("Proxy user"))
-        self._proxy_username_edit.setFixedWidth(self._proxy_host_edit.width())
-        self._proxy_password_edit = PasswordLineEdit()
-        self._proxy_password_edit.setPlaceholderText(_("Password"))
-
-        self._proxy_mode_combo.currentIndexChanged.connect(self._set_proxy)
-        self._proxy_host_edit.editingFinished.connect(self._set_proxy)
-        self._proxy_port_edit.editingFinished.connect(self._set_proxy)
-        self._proxy_username_edit.editingFinished.connect(self._set_proxy)
-        self._proxy_password_edit.editingFinished.connect(self._set_proxy)
-
-        self._proxy_mode_combo.currentIndexChanged.connect(self._proxy_settings_changed)
-        self._proxy_host_edit.textEdited.connect(self._proxy_settings_changed)
-        self._proxy_port_edit.textEdited.connect(self._proxy_settings_changed)
-        self._proxy_username_edit.textEdited.connect(self._proxy_settings_changed)
-        self._proxy_password_edit.textEdited.connect(self._proxy_settings_changed)
-
-        self._tor_checkbox = QCheckBox(_("Use Tor Proxy"))
-        self._tor_checkbox.setIcon(read_QIcon("tor_logo.png"))
-        self._tor_checkbox.hide()
-        self._tor_checkbox.clicked.connect(self._use_tor_proxy)
-
-        grid.addWidget(self._tor_checkbox, 1, 0, 1, 3)
-        grid.addWidget(self._proxy_checkbox, 2, 0, 1, 3)
-        grid.addWidget(HelpButton(_('Proxy settings apply to all connections: both '
-                                    'ElectrumSV servers and third-party services.')), 2, 4)
-        grid.addWidget(self._proxy_mode_combo, 4, 1)
-        grid.addWidget(self._proxy_host_edit, 4, 2)
-        grid.addWidget(self._proxy_port_edit, 4, 3)
-        grid.addWidget(self._proxy_username_edit, 5, 2, Qt.AlignmentFlag.AlignTop)
-        grid.addWidget(self._proxy_password_edit, 5, 3, Qt.AlignmentFlag.AlignTop)
-        grid.setRowStretch(7, 1)
-
-        self._fill_in_proxy_settings()
-
-    def _check_disable_proxy(self, b: bool) -> None:
-        if not app_state.config.is_modifiable('proxy'):
-            b = False
-        for w in [ self._proxy_mode_combo, self._proxy_host_edit, self._proxy_port_edit,
-                self._proxy_username_edit, self._proxy_password_edit ]:
-            w.setEnabled(b)
-
-    def _fill_in_proxy_settings(self) -> None:
-        self._filling_in = True
-        self._check_disable_proxy(self._network.proxy is not None)
-        self._proxy_checkbox.setChecked(self._network.proxy is not None)
-        proxy = self._network.proxy or SVProxy('localhost:9050', 'SOCKS5', None)
-        self._proxy_mode_combo.setCurrentText(proxy.kind())
-        self._proxy_host_edit.setText(str(proxy.host()))
-        self._proxy_port_edit.setText(str(proxy.port()))
-        self._proxy_username_edit.setText(proxy.username())
-        self._proxy_password_edit.setText(proxy.password())
-        self._filling_in = False
-
-    def set_tor_detector(self) -> None:
-        self.td = td = TorDetector()
-        td.found_proxy.connect(self._suggest_proxy)
-        td.start()
-
-    def _set_proxy(self) -> None:
-        if self._filling_in:
-            return
-        proxy: Optional[SVProxy] = None
-        if self._proxy_checkbox.isChecked():
-            auth: Optional[SVUserAuth]
-            try:
-                address = NetAddress(self._proxy_host_edit.text(), self._proxy_port_edit.text())
-                if self._proxy_username_edit.text():
-                    auth = SVUserAuth(self._proxy_username_edit.text(),
-                        self._proxy_password_edit.text())
-                else:
-                    auth = None
-                proxy = SVProxy(address, self._proxy_mode_combo.currentText(), auth)
-            except Exception:
-                logger.exception('error setting proxy')
-        if not proxy:
-            self._tor_checkbox.setChecked(False)
-
-        # Apply the changes.
-        self._network.set_proxy(proxy)
-
-    def _suggest_proxy(self, found_proxy: tuple[str, int]) -> None:
-        self._tor_proxy = found_proxy
-        self._tor_checkbox.setText("Use Tor proxy at port " + str(found_proxy[1]))
-        if (self._proxy_checkbox.isChecked() and
-                self._proxy_mode_combo.currentText() == 'SOCKS5' and
-                self._proxy_host_edit.text() == found_proxy[0] and
-                self._proxy_port_edit.text() == str(found_proxy[1])):
-            self._tor_checkbox.setChecked(True)
-        self._tor_checkbox.show()
-
-    def _use_tor_proxy(self, use_it: bool) -> None:
-        if use_it:
-            self._proxy_mode_combo.setCurrentText('SOCKS5')
-            self._proxy_host_edit.setText(self._tor_proxy[0])
-            self._proxy_port_edit.setText(str(self._tor_proxy[1]))
-            self._proxy_username_edit.setText("")
-            self._proxy_password_edit.setText("")
-            self._proxy_checkbox.setChecked(True)
-        else:
-            self._proxy_checkbox.setChecked(False)
-        self._check_disable_proxy(use_it)
-        self._set_proxy()
-
-    def _proxy_settings_changed(self) -> None:
-        self._tor_checkbox.setChecked(False)
-
-
-class TorDetector(QThread):
-    found_proxy = pyqtSignal(object)
-
-    def __init__(self) -> None:
-        QThread.__init__(self)
-
-    def run(self) -> None:
-        # Probable ports for Tor to listen at
-        ports = [9050, 9150]
-        for p in ports:
-            pair = ('localhost', p)
-            if TorDetector.is_tor_port(pair):
-                self.found_proxy.emit(pair)
-                return
-
-    @staticmethod
-    def is_tor_port(pair: Tuple[str, int]) -> bool:
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.1)
-            s.connect(pair)
-            # Tor responds uniquely to HTTP-like requests
-            s.send(b"GET\n")
-            if b"Tor is not an HTTP Proxy" in s.recv(1024):
-                return True
-        except socket.error:
-            pass
-        return False
-
-
 class NetworkTabsLayout(QVBoxLayout):
     def __init__(self, network: Network) -> None:
         super().__init__()
-        self._tor_proxy = None
         self._filling_in = False
         self._network = network
 
-        self._blockchain_tab = BlockchainTab(self, network)
+        # TODO(1.4.0) - replace with HeaderSV chain tips and local chain state this wallet follows
+        # self._blockchain_tab = BlockchainTab(self, network)
         self._servers_tab = ServersTab(self, network)
-        self._proxy_tab = ProxyTab(network)
 
         self._tabs = QTabWidget()
         self._tabs.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self._tabs.addTab(self._blockchain_tab, _('Blockchain Status'))
+
+        # TODO(1.4.0) - replace with HeaderSV chain tips and local chain state this wallet follows
+        # self._tabs.addTab(self._blockchain_tab, _('Blockchain Status'))
         self._tabs.addTab(self._servers_tab, _('Servers'))
-        self._tabs.addTab(self._proxy_tab, _('Proxy'))
 
         self.addWidget(self._tabs)
         self.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
-        self._proxy_tab.set_tor_detector()
         self.last_values = None
 
-    def follow_server(self, server: SVServer, auto_connect: bool) -> None:
-        self._network.set_server(server, auto_connect)
-        # This updates the blockchain tab too.
-        self._servers_tab.update_servers()
+    # def follow_server(self, server: SVServer, auto_connect: bool) -> None:
+    #     self._network.set_server(server, auto_connect)
+    #     # This updates the blockchain tab too.
+    #     self._servers_tab.update_servers()
 
 
 class NetworkDialog(QDialog):
@@ -1793,7 +1524,7 @@ class NetworkDialog(QDialog):
         super().__init__(flags=Qt.WindowType(Qt.WindowType.WindowSystemMenuHint |
             Qt.WindowType.WindowTitleHint | Qt.WindowType.WindowCloseButtonHint))
         self.setWindowTitle(_('Network'))
-        self.setMinimumSize(500, 200)
+        self.setMinimumSize(500, 350)
         self.resize(560, 400)
 
         self._network = network
@@ -1803,7 +1534,7 @@ class NetworkDialog(QDialog):
         self._buttons_layout.add_left_button(HelpDialogButton(self, "misc", "network-dialog"))
 
         vbox = QVBoxLayout(self)
-        vbox.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
+        # vbox.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
         vbox.addLayout(self._tabs_layout)
         vbox.addLayout(self._buttons_layout)
 

--- a/electrumsv/network_support/api_server.py
+++ b/electrumsv/network_support/api_server.py
@@ -60,7 +60,7 @@ from ..transaction import Transaction
 
 
 if TYPE_CHECKING:
-    from ..network import SVServer, Network
+    from ..network import Network
     from ..wallet import AbstractAccount
 
 __all__ = [ "NewServerAPIContext", "NewServerAccessState", "NewServer" ]
@@ -110,11 +110,6 @@ SERVER_CAPABILITIES = {
         CapabilitySupport(_("Transaction proofs"), ServerCapability.MERKLE_PROOF_NOTIFICATION,
             is_unsupported=True),
     ],
-    NetworkServerType.ELECTRUMX: [
-        CapabilitySupport(_("Blockchain scanning"), ServerCapability.SCRIPTHASH_HISTORY),
-        CapabilitySupport(_("Transaction broadcast"), ServerCapability.TRANSACTION_BROADCAST),
-        CapabilitySupport(_("Transaction proofs"), ServerCapability.MERKLE_PROOF_REQUEST),
-    ]
 }
 
 
@@ -439,7 +434,6 @@ class SelectionCandidate(NamedTuple):
     server_type: NetworkServerType
     credential_id: Optional[IndefiniteCredentialId]
     api_server: Optional[NewServer] = None
-    electrumx_server: Optional["SVServer"] = None
 
 
 def select_servers(capability_type: ServerCapability, candidates: List[SelectionCandidate]) \
@@ -524,10 +518,6 @@ def prioritise_broadcast_servers(estimated_tx_size: TransactionSize,
             assert key_state.last_fee_quote is not None
             estimator = MAPIFeeEstimator(key_state.last_fee_quote)
             fee_estimator = estimator.estimate_fee
-        elif candidate.server_type == NetworkServerType.ELECTRUMX:
-            # NOTE At some point if ElectrumX servers stick around maybe they will do their
-            #   own fee quotes.
-            fee_estimator = electrumx_fee_estimator
         else:
             raise NotImplementedError(f"Unsupported server type {candidate.server_type}")
         initial_fee = fee_estimator(estimated_tx_size)

--- a/electrumsv/network_support/esv_client_types.py
+++ b/electrumsv/network_support/esv_client_types.py
@@ -56,10 +56,8 @@ class HeaderResponse(TypedDict):
     work: int
 
 
-class TipResponse(TypedDict):
-    header: HeaderResponse
-    state: str
-    chainWork: int
+class TipResponse(NamedTuple):
+    header: bytes
     height: int
 
 

--- a/electrumsv/network_support/exceptions.py
+++ b/electrumsv/network_support/exceptions.py
@@ -1,0 +1,18 @@
+# Exceptions are placed here to simplify the import dependency graph and resolve circular imports
+class GeneralAPIError(Exception):
+    pass
+
+class FilterResponseInvalidError(GeneralAPIError):
+    pass
+
+class FilterResponseIncompleteError(GeneralAPIError):
+    pass
+
+class TransactionNotFoundError(GeneralAPIError):
+    pass
+
+class HeaderNotFoundError(GeneralAPIError):
+    pass
+
+class HeaderResponseError(GeneralAPIError):
+    pass

--- a/electrumsv/network_support/general_api.py
+++ b/electrumsv/network_support/general_api.py
@@ -43,6 +43,8 @@ from typing import Any, AsyncIterable, List, NamedTuple, Optional, TypedDict, TY
 import aiohttp
 from bitcoinx import hash_to_hex_str, MissingHeader
 
+from .exceptions import FilterResponseInvalidError, FilterResponseIncompleteError, \
+    TransactionNotFoundError, GeneralAPIError
 from ..app_state import app_state
 from ..bitcoin import TSCMerkleProof, TSCMerkleProofError, verify_proof
 from ..constants import ServerCapability
@@ -90,18 +92,6 @@ RESULT_UNPACK_FORMAT = ">B32s32sI32sI"
 FILTER_RESPONSE_SIZE = 1 + 32 + 32 + 4 + 32 + 4
 assert struct.calcsize(RESULT_UNPACK_FORMAT) == FILTER_RESPONSE_SIZE
 
-
-class GeneralAPIError(Exception):
-    pass
-
-class FilterResponseInvalidError(GeneralAPIError):
-    pass
-
-class FilterResponseIncompleteError(GeneralAPIError):
-    pass
-
-class TransactionNotFoundError(GeneralAPIError):
-    pass
 
 async def post_restoration_filter_request_json(url: str, request_data: RestorationFilterRequest) \
         -> AsyncIterable[RestorationFilterJSONResponse]:

--- a/electrumsv/networks.py
+++ b/electrumsv/networks.py
@@ -60,7 +60,6 @@ class SVMainnet(object):
     ADDRTYPE_P2SH = 5
     CASHADDR_PREFIX = "bitcoincash"
     DEFAULT_PORTS = {'t': '50001', 's': '50002'}
-    DEFAULT_SERVERS_ELECTRUMX = read_json_dict('servers.json')
     DEFAULT_SERVERS_MAPI = read_json_dict('mapi_servers.json')
     DEFAULT_SERVERS_API = read_json_dict('api_servers.json')
     GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
@@ -115,7 +114,6 @@ class SVTestnet(object):
     ADDRTYPE_P2SH = 196
     CASHADDR_PREFIX = "bchtest"
     DEFAULT_PORTS = {'t': '51001', 's': '51002'}
-    DEFAULT_SERVERS_ELECTRUMX = read_json_dict('servers_testnet.json')
     DEFAULT_SERVERS_MAPI = read_json_dict('mapi_servers_testnet.json')
     DEFAULT_SERVERS_API = read_json_dict('api_servers_testnet.json')
     GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
@@ -178,7 +176,6 @@ class SVScalingTestnet(object):
     ADDRTYPE_P2SH = 196
     CASHADDR_PREFIX = "bchtest"
     DEFAULT_PORTS = {'t': '51001', 's': '51002'}
-    DEFAULT_SERVERS_ELECTRUMX = read_json_dict('servers_scalingtestnet.json')
     DEFAULT_SERVERS_MAPI = read_json_dict('mapi_servers_scalingtestnet.json')
     DEFAULT_SERVERS_API = read_json_dict('api_servers_scalingtestnet.json')
     GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
@@ -248,10 +245,9 @@ class SVRegTestnet(object):
     ADDRTYPE_P2SH = 196
     CASHADDR_PREFIX = "bchtest"
     DEFAULT_PORTS = {'t': '51001', 's': '51002'}
-    DEFAULT_SERVERS_ELECTRUMX = read_json_dict('servers_regtest.json')
     DEFAULT_SERVERS_MAPI = read_json_dict('mapi_servers_regtest.json')
     DEFAULT_SERVERS_API = read_json_dict('api_servers_regtest.json')
-    GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+    GENESIS = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
     NAME = NetworkName.REGTEST
     BITCOIN_URI_PREFIX = "bitcoin"
     PAY_URI_PREFIX = "pay"

--- a/electrumsv/simple_config.py
+++ b/electrumsv/simple_config.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 import os
 import stat
@@ -11,7 +12,7 @@ from .constants import DEFAULT_FEE
 from .logs import logs
 from .platform import platform
 from .types import TransactionSize
-from .util import make_dir, JSON
+from .util import make_dir
 
 
 logger = logs.get_logger("config")
@@ -215,7 +216,7 @@ class SimpleConfig:
         if not self.path:
             return
         path = os.path.join(self.path, "config")
-        s = JSON.dumps(self.user_config, indent=4, sort_keys=True)
+        s = json.dumps(self.user_config, indent=4, sort_keys=True)
         with open(path, "w", encoding='utf-8') as f:
             f.write(s)
         os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
@@ -277,7 +278,7 @@ def read_user_config(path: str) -> Dict[str, Any]:
     try:
         with open(config_path, "r", encoding='utf-8') as f:
             data = f.read()
-        result = JSON.loads(data)
+        result = json.loads(data)
     except Exception:
         logger.exception("Cannot read config file %s.", config_path)
         return {}

--- a/electrumsv/subscription.py
+++ b/electrumsv/subscription.py
@@ -166,16 +166,21 @@ class SubscriptionManager:
         key = entry.key
         if key.value_type in BYTE_SUBSCRIPTION_TYPES:
             assert type(key.value) is bytes, "subscribed script hashes must be bytes"
-        subscription_id = self._subscription_ids[key]
-        subscriptions = self._subscriptions[key]
-        subscriptions.remove(owner)
-        self._owner_subscriptions[owner].remove(key)
-        del self._owner_subscription_context[(owner, key)]
-        if len(subscriptions) == 0:
-            del self._subscription_ids[key]
-            del self._subscriptions[key]
-            return subscription_id
-        return None
+        try:
+            subscription_id = self._subscription_ids[key]
+            subscriptions = self._subscriptions[key]
+            subscriptions.remove(owner)
+            self._owner_subscriptions[owner].remove(key)
+            del self._owner_subscription_context[(owner, key)]
+            if len(subscriptions) == 0:
+                del self._subscription_ids[key]
+                del self._subscriptions[key]
+                return subscription_id
+            return None
+        except KeyError:
+            logger.error("Could not remove subscription for key: %s because the subscription does"
+                         "not exist", key)
+            return None
 
     def create_entries(self, entries: List[SubscriptionEntry], owner: SubscriptionOwner) \
             -> List[concurrent.futures.Future[None]]:

--- a/electrumsv/tests/data/reference_server/headers_data.py
+++ b/electrumsv/tests/data/reference_server/headers_data.py
@@ -1,17 +1,12 @@
-GENESIS_TIP = {
-    "header": {
-        "hash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
-        "version": 1,
-        "prevBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
-        "merkleRoot": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
-        "creationTimestamp": 1296688602,
-        "difficultyTarget": 545259519,
-        "nonce": 2,
-        "transactionCount": 0,
-        "work": 2
-    },
-    "state": "LONGEST_CHAIN",
-    "chainWork": 2,
-    "height": 0,
-    "confirmations": 1
-}
+import struct
+
+GENESIS_HEADER = \
+    b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+    b';\xa3\xed\xfdz{\x12\xb2z\xc7,>gv\x8fa\x7f\xc8\x1b\xc3\x88\x8aQ2:\x9f\xb8' \
+    b'\xaaK\x1e^J\xda\xe5IM\xff\xff\x7f \x02\x00\x00\x00'
+raw_header = bytes.fromhex("010000000000000000000000000000000000000000000000000000000000000000000000"
+                           "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494d"
+                           "ffff7f2002000000")
+height_bin = struct.pack('<I', 0)
+GENESIS_TIP_NOTIFICATION_BINARY = raw_header + height_bin

--- a/electrumsv/tests/test_server_api.py
+++ b/electrumsv/tests/test_server_api.py
@@ -52,10 +52,6 @@ def test_select_servers_filter_all_outputs() -> None:
             NetworkServerType.MERCHANT_API,
             None,
             api_server.NewServer("A", NetworkServerType.MERCHANT_API)),
-        api_server.SelectionCandidate(
-            NetworkServerType.ELECTRUMX,
-            None,
-            api_server.NewServer("B", NetworkServerType.ELECTRUMX)),
     ]
     selected_candidates = api_server.select_servers(ServerCapability.TRANSACTION_BROADCAST, servers)
     assert servers == selected_candidates
@@ -67,10 +63,6 @@ def test_select_servers_filter_reduced_outputs() -> None:
             NetworkServerType.MERCHANT_API,
             None,
             api_server.NewServer("A", NetworkServerType.MERCHANT_API)),
-        api_server.SelectionCandidate(
-            NetworkServerType.ELECTRUMX,
-            None,
-            api_server.NewServer("B", NetworkServerType.ELECTRUMX)),
     ]
     selected_candidates = api_server.select_servers(ServerCapability.FEE_QUOTE, servers)
     assert [ servers[0] ] == selected_candidates

--- a/electrumsv/tests/test_wallet.py
+++ b/electrumsv/tests/test_wallet.py
@@ -869,7 +869,6 @@ async def test_transaction_import_removal(mock_app_state, tmp_storage) -> None:
 #     the wallet should detect it and gather all block hashes that are now invalidated and
 #     process the affected transactions. One place where we currently fail at this is where
 #     a wallet was not loaded when the blockchain changed.
-@pytest.mark.skip(reason="pending 1.4.0 header work")
 @pytest.mark.asyncio
 @unittest.mock.patch('electrumsv.wallet.app_state')
 async def test_reorg(mock_app_state, tmp_storage) -> None:
@@ -902,9 +901,10 @@ async def test_reorg(mock_app_state, tmp_storage) -> None:
     db_context = tmp_storage.get_db_context()
     db = db_context.acquire_connection()
     try:
-        BLOCK_HASH = b'CAFECAFE'
-        BLOCK_HEIGHT = 1000
+        BLOCK_HASH_REORGED1 = b'HASH_FOR_REORG1'  # which will affect some txs
         BLOCK_POSITION = 3
+
+        BLOCK_HASH_REORGED2 = b'HASH_FOR_REORG2'  # we have no transactions in this block
 
         ## Add a transaction that is settled.
         tx_1 = Transaction.from_hex(tx_hex_funding)
@@ -913,38 +913,25 @@ async def test_reorg(mock_app_state, tmp_storage) -> None:
         wallet._missing_transactions[tx_hash_1] = MissingTransactionEntry(
             TransactionImportFlag.UNSET)
         link_state = TransactionLinkState()
+
         await wallet.import_transaction_async(tx_hash_1, tx_1, TxFlags.STATE_SETTLED,
-            link_state=link_state)
-
-        class FakeHeader:
-            timestamp: int
-            hash: bytes
-
-        fake_header = cast(Header, FakeHeader())
-        fake_header.timestamp = 1
-        fake_header.height = BLOCK_HEIGHT
-        fake_header.hash = BLOCK_HASH
-
-        await wallet.add_transaction_proof(tx_hash_1, fake_header, BLOCK_POSITION,
-            BLOCK_POSITION, [ b'FAFFFAFF' ] * 10)
+            link_state=link_state, block_hash=BLOCK_HASH_REORGED1, block_position=BLOCK_POSITION,
+            tsc_proof_bytes=b'TSC_FAKE_PROOF_BYTES', import_flags=TransactionImportFlag.EXTERNAL)
 
         tx_metadata_1 = wallet.get_transaction_metadata(tx_hash_1)
         assert tx_metadata_1 is not None
-        assert tx_metadata_1.block_hash == BLOCK_HASH
+        assert tx_metadata_1.block_hash == BLOCK_HASH_REORGED1
         assert tx_metadata_1.block_position == BLOCK_POSITION
-        assert tx_metadata_1.fee_value is None # == FEE_VALUE
+        assert tx_metadata_1.fee_value is None  # == FEE_VALUE
 
         # TODO(1.4.0) This maps to unspent output requirements?
         # ## Verify that the transaction does not qualify for subscriptions.
         # sub_rows = wallet.read_keys_for_transaction_subscriptions(account_row.account_id, tx_hash_1)
         # assert not len(sub_rows)
 
-        ## NOP reorg.
-        # This is the height at which the blockchain was re-orged above. It should not affect the
-        # transaction.
-        wallet.undo_verifications(BLOCK_HEIGHT)
-
-        # Check the flags are the same as we set.
+        # Reorg that doesn't affect our transactions
+        # We have no transactions in this block - there should be no effect
+        wallet.on_reorg([BLOCK_HASH_REORGED2])
         tx_flags1 = db_functions.read_transaction_flags(db_context, tx_hash_1)
         assert tx_flags1 is not None
         assert tx_flags1 == TxFlags.STATE_SETTLED
@@ -952,12 +939,12 @@ async def test_reorg(mock_app_state, tmp_storage) -> None:
         # Check the mined metadata is the same as we set.
         tx_metadata_1 = wallet.get_transaction_metadata(tx_hash_1)
         assert tx_metadata_1 is not None
-        assert tx_metadata_1.block_hash == BLOCK_HASH
+        assert tx_metadata_1.block_hash == BLOCK_HASH_REORGED1
         assert tx_metadata_1.block_position == BLOCK_POSITION
         assert tx_metadata_1.fee_value is None # == FEE_VALUE
 
-        ## Real reorg.
-        wallet.undo_verifications(BLOCK_HEIGHT-1)
+        # Real reorg.
+        wallet.on_reorg([BLOCK_HASH_REORGED1])
 
         # Check that the expectation is that the nodes have for now moved it back into the mempool.
         tx_flags1 = db_functions.read_transaction_flags(db_context, tx_hash_1)

--- a/electrumsv/tests/test_wallet_database_tables.py
+++ b/electrumsv/tests/test_wallet_database_tables.py
@@ -1411,7 +1411,7 @@ def test_read_proofless_transactions(db_context: DatabaseContext) -> None:
 
 def test_table_servers_CRUD(db_context: DatabaseContext) -> None:
     ACCOUNT_ID = 10
-    SERVER_TYPE = NetworkServerType.ELECTRUMX
+    SERVER_TYPE = NetworkServerType.GENERAL
     UNUSED_SERVER_TYPE = NetworkServerType.MERCHANT_API
     date_updated = 1
     URL = "..."

--- a/electrumsv/util/__init__.py
+++ b/electrumsv/util/__init__.py
@@ -74,37 +74,6 @@ class MyEncoder(json.JSONEncoder):
         return super(MyEncoder, self).default(o)
 
 
-class JSON:
-    classes: Dict[str, Any] = {}
-
-    @classmethod
-    def register(cls, *classes: Any) -> None:
-        for klass in classes:
-            cls.classes[klass.__name__] = klass
-
-    @classmethod
-    def dumps(cls, obj: Any, **kwargs: Any) -> str:
-        def encode_obj(obj: Any) -> Dict[str, Any]:
-            class_name = obj.__class__.__name__
-            if class_name not in cls.classes:
-                raise TypeError(f'object of type {class_name} is not JSON serializable')
-            return {'_sv': (class_name, obj.to_json())}
-
-        kwargs['default'] = encode_obj
-        return json.dumps(obj, **kwargs)
-
-    @classmethod
-    def loads(cls, s: Union[str, bytes], **kwargs: Any) -> Any:
-        def decode_obj(obj: Dict[str, Any]) -> Any:
-            if '_sv' in obj:
-                class_name, ser = obj['_sv']
-                obj = cls.classes[class_name].from_json(ser)
-            return obj
-
-        kwargs['object_hook'] = decode_obj
-        return json.loads(s, **kwargs)
-
-
 class DaemonThread(threading.Thread):
     """ daemon thread that terminates cleanly """
 

--- a/electrumsv/util/misc.py
+++ b/electrumsv/util/misc.py
@@ -4,10 +4,10 @@ import os
 import platform
 from sys import getsizeof
 import subprocess
-from typing import Any, Generator
+from typing import Any, Generator, List
 import uuid
 
-from bitcoinx import Script
+from bitcoinx import Script, hash_to_hex_str
 
 from electrumsv.constants import ScriptType
 from electrumsv.transaction import Transaction, XTxInput, XTxOutput, XPublicKey
@@ -130,3 +130,7 @@ def get_system_uuid() -> uuid.UUID:
         return get_macos_system_uuid()
     else:
         return get_linux_system_uuid()
+
+
+def fmt_hashes_to_hex_str(hashes: List[bytes]) -> List[str]:
+    return [hash_to_hex_str(h) for h in hashes]

--- a/electrumsv/wallet_support/late_header_worker.py
+++ b/electrumsv/wallet_support/late_header_worker.py
@@ -103,6 +103,7 @@ async def _process_one_item(db_functions_async: AsynchronousFunctions,
     there is.
     """
     item_kind, item_any = await state.late_header_worker_queue.get()
+    logger.debug("Late header worker task got: %s", item_kind)
     if item_kind == PendingHeaderWorkKind.MERKLE_PROOF:
         tsc_proof = cast(TSCMerkleProof, item_any)
         await _process_merkle_proof(db_functions_async, state, tsc_proof)


### PR DESCRIPTION
- Replaced ElectrumX header APIs with new ElectrumSV-Reference-Server APIs.
- Reorgs are handled. However, the transactions are reset to
STATE_CLEARED with NULL proof data and we do not yet have a task to
pick them up and process them.
- Uses binary header APIs wherever practical to do so.
- Removed most dead code related to ElectrumX which helped reduce cognitive load.
- The proxy tab of network_dialogue.py is deleted but the BlockchainTab and NodesListWidget code has been commented out to defer the work for later (to represent the HeaderSV chain tips instead of ElectrumX sessions).
- Moved GeneralAPIError exceptions to their own file to resolve circular import issues.
- UI correctly shows server status as either being behind x number of blocks, connected or main server pending.