### PR TITLE
Fix #140. The `run_non_RPC` entrypoint never reads the headers store …

### DIFF
--- a/.azure-pipelines/run_functional_tests.yml
+++ b/.azure-pipelines/run_functional_tests.yml
@@ -14,6 +14,6 @@ steps:
     electrumsv-sdk install node
     electrumsv-sdk install simple_indexer
     electrumsv-sdk install reference_server
-    electrumsv-sdk install --repo=$PWD electrumsv
+    electrumsv-sdk install --repo=$PWD --branch=${Build.SourceBranch} electrumsv
     python3 -m pytest -v -v -v contrib/functional_tests/functional
   displayName: 'Functional tests (via SDK & REST API)'

--- a/electrumsv/main.py
+++ b/electrumsv/main.py
@@ -88,6 +88,7 @@ def run_non_RPC(config: SimpleConfig) -> None:
         return final_path
 
     if cmdname in {'create_wallet', 'create_account'}:
+        app_state.read_headers()
         password: Optional[str]
         if not config.cmdline_options.get('nopasswordcheck'):
             password = prompt_password("Password: ")


### PR DESCRIPTION
…and so `app_state.headers` is None and fails an assertion check