### PR TITLE
Clean up existing TODO items in node wallet api documentation

### DIFF
--- a/docs/standalone/building-on-electrumsv/codebase-reference.rst
+++ b/docs/standalone/building-on-electrumsv/codebase-reference.rst
@@ -16,7 +16,7 @@ get involved in the project.
 
 Blockchain headers
     ElectrumSV is a P2P wallet and is limited by the network access the user running it has.
-    While in the longer term we will obtan headers from the Bitcoin P2P network if possible,
+    While in the longer term we will obtain headers from the Bitcoin P2P network if possible,
     in the shorter term we need to focus on consistently reliable ways of obtaining headers.
     At this time headers are obtained via a standard REST API from remote servers. Read more about
     :doc:`how ElectrumSV obtains and uses headers <codebase-reference/blockchain-headers>`.

--- a/docs/standalone/conf.py
+++ b/docs/standalone/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'ElectrumSV'
-copyright = '2020, The ElectrumSV developers'
+copyright = '2020, 2021, 2022, The ElectrumSV developers'
 author = 'The ElectrumSV developers'
 
 

--- a/docs/standalone/index.rst
+++ b/docs/standalone/index.rst
@@ -96,6 +96,23 @@ What if I do not want to upgrade to the latest version?
    /problem-solving/macos
    /problem-solving/upgrade-concerns
 
+Using ElectrumSV
+----------------
+
+Where are the wallet files stored?
+    When the wallet application is run it will store and look for related files like blockchain
+    headers, wallet settings and wallets in either a standard folder location on the user's
+    computer, or in a custom location they have explicitly specified.
+    Read more about
+    :doc:`data directories <using-electrumsv/data-directories>`.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Using ElectrumSV
+
+   /using-electrumsv/data-directories
+
 Building on ElectrumSV
 ----------------------
 

--- a/docs/standalone/using-electrumsv/data-directories.rst
+++ b/docs/standalone/using-electrumsv/data-directories.rst
@@ -1,0 +1,84 @@
+Data directories
+================
+
+.. _data-directories:
+
+Wallet data is stored in what is called the ElectrumSV data directory. When the application
+starts up, it looks for the data directory in an expected location, and creates it if it does not
+already exist.
+
+Standard locations
+------------------
+
+Unless the user overrides the default behaviour, the data directory will be on a standard location.
+
+On Linux and MacOS, this will be what is called a hidden folder (it starts with the dot
+character ".") in the user's home directory always named ``.electrum-sv``. This should be easy
+to find.
+
+.. code-block:: console
+    :caption: Linux / MacOS
+
+    $ ls -a ~/ | grep elec
+    .electrum-sv
+
+On Windows, this will be within the user's application data directories. We currently store
+most of the application data in the ``Roaming`` directory and the logs in the ``Local`` directory.
+As log files may become quite large in the more verbose debugging levels, these are placed
+where they won't be synchronised between computers. This is a little harder to find, but by
+substituting your user name for "Bob" below you should be able to find it.
+
+.. code-block:: doscon
+    :caption: Windows
+
+    C:\Users\Bob>dir AppData\Roaming\Elec*
+    ...
+     Directory of C:\Users\Bob\AppData\Roaming
+
+    28/10/2022  08:54 AM    <DIR>          ElectrumSV
+
+
+    C:\Users\Bob>dir AppData\Local\Elec*
+    ...
+     Directory of C:\Users\Bob\AppData\Local
+
+    25/10/2022  06:47 AM    <DIR>          ElectrumSV
+
+Custom locations
+----------------
+
+The simplest way to control where your ElectrumSV data directory is located is to use the
+portable download we provide, this creates and uses an ``electrum_sv_data`` data directory in the
+same directory as the portable build executable is located in.
+
+It is also possible to run ElectrumSV from either the source code or our non-portable build, and
+to tell it where to look for and place it's data directory. This can be done with the ``-D``
+command-line parameter.
+
+.. code-block:: console
+    :caption: Linux / MacOS
+
+    $ ./electrum-sv -D INSTANCE1
+    2022-11-25 12:59:34,966:INFO:rest-server:REST API started on http://127.0.0.1:9999
+    ...
+    $ ls | grep INSTANCE
+    INSTANCE1
+
+.. code-block:: doscon
+    :caption: Windows
+
+    C:\Data\Git\electrumsv>py electrum-sv -D INSTANCE1
+    2022-11-25 12:59:34,966:INFO:rest-server:REST API started on http://127.0.0.1:9999
+    ...
+    C:\Data\Git\electrumsv>dir INSTANCE
+    ...
+     Directory of C:\Data\Git\electrumsv
+
+    25/11/2022  12:59 PM    <DIR>          INSTANCE1
+
+.. note::
+
+    Only one instance of ElectrumSV can be run at a time. The way this is enforced is through
+    the data directory, and as by default an application instance will use the standard location
+    only the first instance will run and any subsequent instance will exit. However, if each
+    subsequent instance is directed to use a custom data directory, they will run at the same time.

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -131,7 +131,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
     keys_created_signal = pyqtSignal(object, object)
     notifications_created_signal = pyqtSignal(object)
     notifications_updated_signal = pyqtSignal(object)
-    transaction_state_signal = pyqtSignal(object, object, object)
+    transaction_state_signal = pyqtSignal(object, object)
     transaction_added_signal = pyqtSignal(object, object, object)
     transaction_deleted_signal = pyqtSignal(object, object)
     transaction_verified_signal = pyqtSignal(object, object, object)
@@ -2415,8 +2415,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
         self.history_view.update_descriptions(update_entries)
         self.utxo_list.update_tx_labels(update_entries)
 
-    def _on_transaction_state_change(self, account_id: int, tx_hash: bytes,
-            new_state: TxFlags) -> None:
+    def _on_transaction_state_change(self, tx_hash: bytes, new_state: TxFlags) -> None:
         self.update_history_view()
 
     def update_history_view(self) -> None:

--- a/examples/applications/restapi/app.py
+++ b/examples/applications/restapi/app.py
@@ -63,7 +63,7 @@ class RESTAPIApplication:
     async def async_on_triggered_event(self, *event_data: Any) -> None:
         event_name = event_data[0]
         if event_name == WalletEventNames.TRANSACTION_STATE_CHANGE:
-            _event_name, _acc_id, tx_hash, existing_flags, updated_flags = event_data
+            _event_name, tx_hash, existing_flags, updated_flags = event_data
             await self._tx_state_push_notification(tx_hash)
         elif event_name == WalletEventNames.TRANSACTION_ADDED:
             _event_name, tx_hash, _tx, _involved_account_ids, _external = event_data

--- a/examples/applications/restapi/tests/test_restapi_handlers.py
+++ b/examples/applications/restapi/tests/test_restapi_handlers.py
@@ -200,10 +200,6 @@ class MockWallet(Wallet):
     def get_id(self) -> int:
         return 32323232
 
-    async def set_transaction_state_async(self, tx_hash: bytes, flags: TxFlags,
-            ignore_mask: Optional[TxFlags]=None) -> bool:
-        return True
-
 
 class MockApp:
     def __init__(self):


### PR DESCRIPTION
- Go over the `walletnotify` implementation and make sure it handles all state transitions including reorgs.
  - This should also clean up the general `TRANSACTION_STATE_CHANGE` wallet event.
- Flesh out `sendtoaddress` with more correct error handling.
- Went over all the node API documentation listed errors and made sure they are correct.