### PR TITLE
Fix issue #995. Normal reference server disconnections not handled.

### DIFF
--- a/electrumsv/network_support/peer_channel.py
+++ b/electrumsv/network_support/peer_channel.py
@@ -416,7 +416,7 @@ async def process_externally_owned_peer_channel_messages_async(state: PeerChanne
     logger.debug("Entering process_externally_owned_peer_channel_messages_async, server_url=%s "
                  "(Wallet='%s')", state.server_url, state.wallet_proxy.name())
 
-    while state.connection_flags & ServerConnectionFlag.EXITING == 0:
+    while state.connection_flags & ServerConnectionFlag.MASK_EXIT == 0:
         state.processing_message_event.clear()
         remote_channel_id = await state.peer_channel_message_queue.get()
         state.processing_message_event.set()
@@ -491,7 +491,7 @@ async def maintain_external_peer_channel_connection_async(state: PeerChannelServ
     state.connection_flags |= ServerConnectionFlag.STARTING
 
     try:
-        while state.connection_flags & ServerConnectionFlag.EXITING == 0:
+        while state.connection_flags & ServerConnectionFlag.MASK_EXIT == 0:
             state.connection_flags &= ServerConnectionFlag.MASK_COMMON_INITIAL
 
             # Both the connection management task and worker tasks.


### PR DESCRIPTION
This pull request hooks onto the existing unexpected problem handling and reconnects naturally when a server disconnects. It is also compatible with cleanly exiting ElectrumSV without problems where the network is being shut down.

- Normal disconnection now raises a `ServerDisconnectionError` which gets piped to `_on_server_connection_worker_task_done` and handled like other problematic disconnection states (which at this point is waiting and retrying). So now we reconnect after a few seconds.
- Server-connection loops now exit based on `ServerConnectionFlag.MASK_EXIT` instead of `ServerConnectionFlag.STATE_EXITING`. This was not causing a problem, but makes more sense to ensure that if we are in a state related to existing, we do not reloop assuming the task does not get cancelled (which bypasses the loop of course).