### PR TITLE
Fix the "service_signup" daemon subcommand.

### DIFF
--- a/electrumsv/gui/qt/app.py
+++ b/electrumsv/gui/qt/app.py
@@ -370,7 +370,7 @@ class SVApplication(QApplication):
         self.timer.start()
         signal.signal(signal.SIGINT, lambda *args: self.quit())
         self.initial_dialogs()
-        path = app_state.config.get_cmdline_wallet_filepath()
+        path = app_state.config.get_commandline_wallet_path()
         if not self.start_new_window(path, app_state.config.get('url'), is_startup=True):
             self.quit()
 

--- a/electrumsv/gui/qt/invoice_list.py
+++ b/electrumsv/gui/qt/invoice_list.py
@@ -182,7 +182,7 @@ class InvoiceList(MyTreeWidget):
     #   https://github.com/electrumsv/electrumsv/blob/sv-1.2.5/electrumsv/paymentrequest.py#L523
     # def import_invoices(self, account: AbstractAccount) -> None:
     #     try:
-    #         wallet_folder = self.config.get_preferred_wallet_dirpath()
+    #         wallet_folder = self.config.get_wallet_directory_path()
     #     except FileNotFoundError as e:
     #         self._main_window.show_error(str(e))
     #         return

--- a/electrumsv/gui/qt/main_window.py
+++ b/electrumsv/gui/qt/main_window.py
@@ -678,7 +678,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
 
     def _open_wallet(self) -> None:
         try:
-            wallet_folder = self.config.get_preferred_wallet_dirpath()
+            wallet_folder = self.config.get_wallet_directory_path()
         except FileNotFoundError as e:
             self.show_error(str(e))
             return
@@ -694,7 +694,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin):
 
     def _new_wallet(self) -> None:
         try:
-            wallet_folder = self.config.get_preferred_wallet_dirpath()
+            wallet_folder = self.config.get_wallet_directory_path()
         except FileNotFoundError as e:
             self.show_error(str(e))
             return

--- a/electrumsv/gui/qt/wallet_wizard.py
+++ b/electrumsv/gui/qt/wallet_wizard.py
@@ -609,7 +609,7 @@ class ChooseWalletPage(QWizardPage):
         return True
 
     def _event_click_create_wallet(self) -> None:
-        initial_path = app_state.config.get_preferred_wallet_dirpath()
+        initial_path = app_state.config.get_wallet_directory_path()
         create_filepath = create_new_wallet(self, initial_path)
         if create_filepath is not None:
             # How the app knows which wallet was selected/created.
@@ -622,7 +622,7 @@ class ChooseWalletPage(QWizardPage):
             wizard.accept()
 
     def _event_click_open_file(self) -> None:
-        initial_dirpath = app_state.config.get_preferred_wallet_dirpath()
+        initial_dirpath = app_state.config.get_wallet_directory_path()
         wallet_filepath, __ = QFileDialog.getOpenFileName(self, "Select your wallet file",
             initial_dirpath)
         if wallet_filepath:

--- a/electrumsv/main.py
+++ b/electrumsv/main.py
@@ -78,7 +78,7 @@ def run_non_RPC(config: SimpleConfig) -> None:
     cmdname = config.get_optional_type(str, 'cmd')
 
     def get_wallet_path() -> str:
-        wallet_path = config.get_cmdline_wallet_filepath()
+        wallet_path = config.get_commandline_wallet_path()
         if wallet_path is None:
             sys.exit("error: no wallet path provided")
 
@@ -117,7 +117,7 @@ def run_non_RPC(config: SimpleConfig) -> None:
 
         elif cmdname == "create_jsonrpc_wallet":
             # This is the wallet path in the data directory.
-            wallet_folder_path = config.get_default_wallet_dirpath()
+            wallet_folder_path = config.get_wallet_directory_path()
             # The calling context already checked that the filename is provided.
             wallet_filename = cast(str, config.get('wallet_path'))
             # As we expect wallet files usable with the JSON-RPC API to be located in the
@@ -146,7 +146,7 @@ def run_non_RPC(config: SimpleConfig) -> None:
             sys.exit(0)
 
         elif cmdname == "create_account":
-            wallet_path = cast(str, config.get_cmdline_wallet_filepath())
+            wallet_path = cast(str, config.get_commandline_wallet_path())
             password_token = app_state.credentials.set_wallet_password(wallet_path, password,
                 CredentialPolicyFlag.FLUSH_ALMOST_IMMEDIATELY)
             assert password_token is not None
@@ -214,7 +214,7 @@ def init_cmdline(config_options: dict[str, Any]) -> tuple[Command, str|None]:
     assert isinstance(cmdname, str)
     cmd = known_commands[cmdname.replace("-", "_")]
 
-    wallet_path = config.get_cmdline_wallet_filepath()
+    wallet_path = config.get_commandline_wallet_path()
     if cmd.requires_wallet and not WalletStorage.files_are_matched_by_path(wallet_path):
         sys.exit("Error: wallet file not found")
 
@@ -246,7 +246,7 @@ def run_offline_command(config: SimpleConfig, config_options: dict[str, Any]) ->
     wallet: Wallet|None
 
     if cmd.requires_wallet:
-        wallet_path = config.get_cmdline_wallet_filepath()
+        wallet_path = config.get_commandline_wallet_path()
         if not WalletStorage.files_are_matched_by_path(wallet_path):
             sys.exit("Error: wallet does not exist at given path")
 
@@ -395,6 +395,10 @@ def main() -> None:
 
     config_options = get_config_options()
     logs.set_level(config_options['verbose'])
+
+    # The applications working directory should never change. The reason we store this is because
+    # `config_options` is passed to the daemon with daemon subcommand calls and this is useful
+    # context.
     config_options['cwd'] = os.getcwd()
 
     # fixme: this can probably be achieved with a runtime hook (pyinstaller)

--- a/electrumsv/nodeapi.py
+++ b/electrumsv/nodeapi.py
@@ -382,7 +382,7 @@ def get_wallet_from_request(request: web.Request, request_id: RequestIdType,
         return None
 
     try:
-        wallet_folder_path = app_state.config.get_preferred_wallet_dirpath()
+        wallet_folder_path = app_state.config.get_wallet_directory_path()
     except FileNotFoundError:
         raise web.HTTPInternalServerError(headers={ "Content-Type": "application/json" },
                 text=json.dumps(ResponseDict(id=request_id, result=None,

--- a/electrumsv/restapi_endpoints.py
+++ b/electrumsv/restapi_endpoints.py
@@ -162,7 +162,7 @@ class LocalEndpoints:
         """ Load an existing wallet or get the loaded status of it if it is already loaded. """
         check_network_for_request(request)
         try:
-            wallet_folder_path = app_state.config.get_preferred_wallet_dirpath()
+            wallet_folder_path = app_state.config.get_wallet_directory_path()
         except FileNotFoundError:
             raise web.HTTPInternalServerError(reason="No preferred wallet path")
 
@@ -210,7 +210,7 @@ class LocalEndpoints:
         """ Creates a new wallet using a specified file name and password. """
         check_network_for_request(request)
         try:
-            wallet_folder_path = app_state.config.get_preferred_wallet_dirpath()
+            wallet_folder_path = app_state.config.get_wallet_directory_path()
         except FileNotFoundError:
             raise web.HTTPInternalServerError(reason="No preferred wallet path")
 

--- a/electrumsv/tests/test_nodeapi.py
+++ b/electrumsv/tests/test_nodeapi.py
@@ -202,7 +202,7 @@ def test_get_wallet_from_request_explicit_fail_no_path(app_state_nodeapi: AppSta
 
     def dummy_get_path() -> str:
         raise FileNotFoundError()
-    app_state_nodeapi.config.get_preferred_wallet_dirpath.side_effect = dummy_get_path
+    app_state_nodeapi.config.get_wallet_directory_path.side_effect = dummy_get_path
 
     with pytest.raises(web.HTTPInternalServerError) as exception_value:
         nodeapi.get_wallet_from_request(mock_request, 444)
@@ -228,7 +228,7 @@ def test_get_wallet_from_request_explicit_success(app_state_nodeapi: AppStatePro
 
     def dummy_get_path() -> str:
         return "leading_path"
-    app_state_nodeapi.config.get_preferred_wallet_dirpath.side_effect = dummy_get_path
+    app_state_nodeapi.config.get_wallet_directory_path.side_effect = dummy_get_path
     def dummy_get_wallet(file_name: str) -> Wallet | None:
         nonlocal dummy_wallet
         if file_name == expected_path:

--- a/electrumsv/tests/test_restapi_endpoints.py
+++ b/electrumsv/tests/test_restapi_endpoints.py
@@ -21,7 +21,7 @@ from electrumsv.wallet import Wallet
 async def test_load_wallet_async_daemon_fail(mock_app_state: AppStateProxy, tmp_path: Path) -> None:
     """ Load a wallet unsuccessfully because it does not exist. """
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    mock_app_state.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    mock_app_state.config.get_wallet_directory_path = lambda: str(tmp_path)
     # Inject a failed wallet load so the daemon does not have to exist.
     mock_app_state.daemon.load_wallet = lambda wallet_path: None # type: ignore
     request = unittest.mock.Mock()
@@ -51,7 +51,7 @@ async def test_load_wallet_async_daemon_success(app_state_restapi: AppStateProxy
     """ Load a wallet successfully. """
     wallet: Wallet | None = None
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # Inject the wallet so the daemon does not have to exist.
     app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -86,7 +86,7 @@ async def test_load_wallet_async_daemon_success(app_state_restapi: AppStateProxy
 async def test_create_wallet_async_invalid_body(mock_app_state: AppStateProxy, tmp_path: Path) \
         -> None:
     """ Create a wallet with an invalid body. """
-    mock_app_state.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    mock_app_state.config.get_wallet_directory_path = lambda: str(tmp_path)
     request = unittest.mock.Mock()
     request.match_info = {
         "network": "mainnet",
@@ -104,7 +104,7 @@ async def test_create_wallet_async_invalid_body(mock_app_state: AppStateProxy, t
 async def test_create_wallet_async_invalid_file_name(mock_app_state: AppStateProxy,
         tmp_path: Path) -> None:
     """ Create a wallet with invalid file name in the body. """
-    mock_app_state.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    mock_app_state.config.get_wallet_directory_path = lambda: str(tmp_path)
     request = unittest.mock.Mock()
     request.match_info = {
         "network": "mainnet",
@@ -125,7 +125,7 @@ async def test_create_wallet_async_invalid_file_name(mock_app_state: AppStatePro
 async def test_create_wallet_async_invalid_password(mock_app_state: AppStateProxy, tmp_path: Path) \
         -> None:
     """ Create a wallet with invalid password in the body. """
-    mock_app_state.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    mock_app_state.config.get_wallet_directory_path = lambda: str(tmp_path)
     request = unittest.mock.Mock()
     request.match_info = {
         "network": "mainnet",
@@ -153,7 +153,7 @@ async def test_create_wallet_async_success_no_seed(app_state_restapi: AppStatePr
     """ Create a wallet and do not provide a public key so we get just the basic data back. """
     password_token = unittest.mock.Mock()
     password_token.password = "123456"
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     app_state_restapi.credentials.set_wallet_password = lambda *args: password_token # type: ignore
     request = unittest.mock.Mock()
     request.match_info = {
@@ -191,7 +191,7 @@ async def test_create_wallet_async_success_encrypted_seed(app_state_restapi: App
     """ Create a wallet but provide a public key so we get the encrypted seed words back. """
     password_token = unittest.mock.Mock()
     password_token.password = "123456"
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     app_state_restapi.credentials.set_wallet_password = lambda *args: password_token # type: ignore
     private_key = PrivateKey.from_random()
     public_key = private_key.public_key
@@ -241,7 +241,7 @@ async def test_create_account_async_success(app_state_restapi: AppStateProxy,
     """ Create an account. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -295,7 +295,7 @@ async def test_create_account_async_fail_no_wallet(app_state_restapi: AppStatePr
 
     password_token = unittest.mock.Mock()
     password_token.password = "123456"
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     app_state_restapi.daemon.get_wallet_by_id = get_wallet_by_id
     app_state_restapi.credentials.set_wallet_password = lambda *args: password_token # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -329,7 +329,7 @@ async def test_create_account_async_bad_wallet_id(app_state_restapi: AppStatePro
     """ Create an account. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -378,7 +378,7 @@ async def test_create_account_async_fail_wallet_password(app_state_restapi: AppS
     """ Create an account. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -431,7 +431,7 @@ async def test_create_hosted_invoice_async_success(app_state_restapi: AppStatePr
     """ Create a hosted invoice. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -501,7 +501,7 @@ async def test_create_hosted_invoice_async_fail_no_servers(app_state_restapi: Ap
     """ Create a hosted invoice. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.
@@ -556,7 +556,7 @@ async def test_create_hosted_invoice_async_fail_connect_timeout(app_state_restap
     """ Create a hosted invoice. """
     # BOILERPLATE STARTS
     # Inject a wallet path so our folder path isn't a stringified magic mock.
-    app_state_restapi.config.get_preferred_wallet_dirpath = lambda: str(tmp_path)
+    app_state_restapi.config.get_wallet_directory_path = lambda: str(tmp_path)
     # # Inject the wallet so the daemon does not have to exist.
     # app_state_restapi.daemon.load_wallet = lambda wallet_path: wallet # type: ignore
     # Ensure the wallet can access the password when being loaded.

--- a/electrumsv/util/__init__.py
+++ b/electrumsv/util/__init__.py
@@ -22,7 +22,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import concurrent.futures
 from decimal import Decimal
 from datetime import datetime, timedelta, tzinfo
 import json
@@ -139,19 +138,6 @@ def profiler(func: Callable[..., T1]) -> Callable[..., T1]:
         logger.debug("%s %.8f", n, t)
         return o
     return lambda *args, **kw_args: do_profile(func, args, kw_args)
-
-
-def assert_datadir_available(config_path: str) -> None:
-    """
-    Raises `FileNotFoundError` if the given path is not found.
-    """
-    path = config_path
-    if os.path.exists(path):
-        return
-    else:
-        raise FileNotFoundError(
-            'ElectrumSV datadir does not exist. Was it deleted while running?' + '\n' +
-            'Should be at {}'.format(path))
 
 
 def make_dir(path: str) -> None:


### PR DESCRIPTION
- The part where the connection is established to the server providing the services after the account was created on that server, was not hooked up. It now is, and has been observed to work.
- The daemon is responsible for tracking all loaded wallets. This was depending on the code path done either with relative or absolute wallet paths, which left opportunity for error.
  - Now all daemon path access asserts that the paths have to be absolute.
- The "command-line wallet path" handling is cleaned up and should work correctly. This is where wallet paths are based on the stored `'cwd'` value.
- General pathing is cleaned up. It's not perfect, but it will have to do for now.