### PR TITLE
Fix issue #1002. Default to using the local headers store longest chain.

### DIFF
--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -4269,6 +4269,15 @@ class Wallet:
         # TODO(1.4.0) Networking, issue#841. These worker tasks should be restarted if they
         #     prematurely exit?
 
+        # If the reference server is offline `self.start_reference_server_connection_async`
+        # will block and `self._current_chain` will remin unset.
+        # This will cause header lookups to fail which in turn causes other issues such as "unknown"
+        # timestamps of transactions in the history tab of the UI.
+        # Instead we always initialise the wallet's self._current_chain from the local header store
+        # longest chain as the initial default and then switch chains as needed once we've
+        # connected to the remote server.
+        await self._initialise_headers_from_header_store()
+
         # These are the servers the user has opted to use primarily whether through manual or
         # automatic choice.
         for server, usage_flags in self.get_wallet_servers():
@@ -6601,7 +6610,7 @@ class Wallet:
 
         The wallet cannot allow access to the header store as a way of asserting what the wallet
         does or does not know about the blockchain. What the wallet knows about the blockchain
-        is dependent on it's header source, which in the case of a blockchain service provider
+        is dependent on its header source, which in the case of a blockchain service provider
         will have to follow the chain state of that provider.
 
         All chain state access relative to a given wallet should happen through the `Wallet`


### PR DESCRIPTION
- Otherwise if the reference server is offline, `Wallet._current_chain` will remain unset and cause header lookups to fail
- This is what leads to the "unknown" timestamps in the history tab of the UI.
- If the reference server is offline at startup then it will hang in `start_reference_server_connection_async` at `wait_until_header_server_is_ready_async`
- If the reference server was initially connected but goes offline, it will infinite loop, retrying to reconnect in `maintain_server_connection_async` and the Wallet._current_chain will remain unchanged. Unless updated by some other external headers source.


@rt121212121 I am still evaluating if this minimal change can stand up to scrutiny but looks like the most obvious move.