### PR TITLE
Implement `listunspent` JSON-RPC endpoint.

### DIFF
--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -303,7 +303,6 @@ class TransactionOutputFlag(IntFlag):
     # if allocated then ideally we might extend this to prevent further dispatch in any form.
     FROZEN              = 1 << 3
     COINBASE            = 1 << 4
-    COINBASE_IMMATURE   = 1 << 5
 
 
 class PaymentFlag(IntFlag):

--- a/electrumsv/credentials.py
+++ b/electrumsv/credentials.py
@@ -142,7 +142,6 @@ class CredentialCache:
         if not wallet_path.endswith(DATABASE_EXT):
             wallet_path += DATABASE_EXT
         with self._credential_lock:
-            assert wallet_path not in self._wallet_credentials
             creation_time = time.time()
             encrypted_value = cast(bytes, self._public_key.encrypt_message(password))
             if policy is None or policy & CredentialPolicyFlag.DISCARD_IMMEDIATELY:

--- a/electrumsv/gui/qt/utxo_list.py
+++ b/electrumsv/gui/qt/utxo_list.py
@@ -118,7 +118,7 @@ class UTXOList(MyTreeWidget):
         self.clear()
 
         utxo_rows = self._account.get_transaction_outputs_with_key_and_tx_data(
-            confirmed_only=False, mature=False, exclude_frozen=False)
+            confirmed_only=False, exclude_frozen=False)
         tx_hashes = set(utxo_row.tx_hash for utxo_row in utxo_rows)
         tx_labels: Dict[bytes, str] = {}
         if len(tx_hashes):

--- a/electrumsv/tests/test_nodeapi.py
+++ b/electrumsv/tests/test_nodeapi.py
@@ -13,17 +13,27 @@ import bitcoinx
 import pytest
 
 from electrumsv.app_state import AppStateProxy
-from electrumsv.constants import AccountCreationType, KeystoreTextType, PaymentFlag
+from electrumsv.constants import AccountCreationType, KeystoreTextType, DerivationType, \
+    PaymentFlag, ScriptType, TransactionOutputFlag, TxFlags
 from electrumsv.exceptions import InvalidPassword
 from electrumsv.keystore import instantiate_keystore_from_text
 from electrumsv.network_support.types import ServerConnectionState, TipFilterRegistrationJobOutput
 from electrumsv import nodeapi
 from electrumsv.storage import WalletStorage
-from electrumsv.types import FeeEstimatorProtocol, KeyStoreResult, TransactionSize
+from electrumsv.types import KeyStoreResult
 from electrumsv.wallet import StandardAccount, Wallet
-from electrumsv.wallet_database.types import PaymentRequestRow, PaymentRequestOutputRow
+from electrumsv.wallet_database.types import AccountTransactionOutputSpendableRowExtended, \
+    PaymentRequestOutputRow, PaymentRequestRow
 
 from .util import _create_mock_app_state2, MockStorage
+
+
+PUBLIC_KEY_1_HEX = "02573afa26acf04e7cdafe46b39f8cba25f05c76d9a0cf500b9e196d72020931db"
+PUBLIC_KEY_1 = bitcoinx.PublicKey.from_hex(PUBLIC_KEY_1_HEX)
+P2PKH_ADDRESS_1 = PUBLIC_KEY_1.to_address()
+FAKE_DERIVATION_DATA2 = b"sdsdsd"
+FAKE_BLOCK_HASH = b"block hash"
+FAKE_TRANSACTION_HASH = b"txhash"
 
 
 @pytest.fixture
@@ -301,7 +311,6 @@ async def test_server_authentication_good_password_async(server_tester: TestClie
     assert object["error"]["code"] == -32700
     assert object["error"]["message"] == "Top-level object parse error"
 
-
 @pytest.mark.parametrize("id_value,expected_success", ((111, True), ("23232", True), (None, True),
     ({}, False)))
 async def test_server_authentication_call_id_types_async(id_value: nodeapi.RequestIdType,
@@ -367,9 +376,187 @@ async def test_server_authentication_method_unknown_fail_async(server_tester: Te
     assert object["error"]["code"] == -32601
     assert object["error"]["message"] == "Method not found"
 
+@pytest.mark.parametrize("endpoint_name", ("getnewaddress","listunspent","sendtoaddress"))
 @unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_getnewaddress_no_available_server_async(app_state_nodeapi: AppStateProxy,
-        server_tester: TestClient) -> None:
+async def test_call_endpoints_no_account_async(app_state_nodeapi: AppStateProxy,
+        endpoint_name: str, server_tester: TestClient) -> None:
+    assert server_tester.app is not None
+    mock_server = server_tester.app["server"]
+    # Ensure the server does not require authorization to make a call.
+    mock_server._password = ""
+
+    wallets: dict[str, Wallet] = {}
+    irrelevant_path = os.urandom(32).hex()
+    wallet = unittest.mock.Mock()
+    wallets[irrelevant_path] = wallet
+    app_state_nodeapi.daemon.wallets = wallets
+
+    def get_visible_accounts() -> list[StandardAccount]:
+        return []
+    wallet.get_visible_accounts.side_effect = get_visible_accounts
+
+    call_object = {
+        "id": 232,
+        "method": endpoint_name,
+        "params": [],
+    }
+    response = await server_tester.request(path="/", method="POST", json=call_object)
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    object = await response.json()
+    assert len(object) == 3
+    assert object["id"] == 232
+    assert object["result"] is None
+    assert len(object["error"]) == 2
+    assert object["error"]["code"] == -4
+    assert object["error"]["message"] == "Ambiguous account (found 0, expected 1)"
+
+@pytest.mark.parametrize("endpoint_name", ("getnewaddress","listunspent","sendtoaddress"))
+@unittest.mock.patch('electrumsv.nodeapi.app_state')
+async def test_call_endpoints_too_many_accounts_async(app_state_nodeapi: AppStateProxy,
+        endpoint_name: str, server_tester: TestClient) -> None:
+    assert server_tester.app is not None
+    mock_server = server_tester.app["server"]
+    # Ensure the server does not require authorization to make a call.
+    mock_server._password = ""
+
+    wallets: dict[str, Wallet] = {}
+    irrelevant_path = os.urandom(32).hex()
+    wallet = unittest.mock.Mock()
+    wallets[irrelevant_path] = wallet
+    app_state_nodeapi.daemon.wallets = wallets
+
+    mock_account1 = unittest.mock.Mock(spec=StandardAccount)
+    mock_account2 = unittest.mock.Mock(spec=StandardAccount)
+    def get_visible_accounts() -> list[StandardAccount]:
+        return [ mock_account1, mock_account2 ]
+    wallet.get_visible_accounts.side_effect = get_visible_accounts
+
+    call_object = {
+        "id": 232,
+        "method": endpoint_name,
+        "params": [],
+    }
+    response = await server_tester.request(path="/", method="POST", json=call_object)
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    object = await response.json()
+    assert len(object) == 3
+    assert object["id"] == 232
+    assert object["result"] is None
+    assert len(object["error"]) == 2
+    assert object["error"]["code"] == -4
+    assert object["error"]["message"] == "Ambiguous account (found 2, expected 1)"
+
+# We are checking that methods check their parameters. We do not need to check every permutation of
+# every type check, as the unit testing of the type checking functions already does that.
+@pytest.mark.parametrize("endpoint_name,parameter_list,error_code,error_text", [
+    ## ``listunspent``: ``minconf`` parameter
+    # Error case: RPC_PARSE_ERROR / String in place of minimum confirmation count.
+    ("listunspent", [ "string" ], -32700,
+        "JSON value is not an integer as expected"),
+    # Error case: RPC_PARSE_ERROR / String in place of maximum confirmation count.
+    ("listunspent", [ 0, "string" ], -32700,
+        "JSON value is not an integer as expected"),
+    # Error case: RPC_TYPE_ERROR / Non-list in place of filter address list.
+    ("listunspent", [ None, None, 1 ], -3,
+        "Expected type list, got int"),
+    # Error case: RPC_PARSE_ERROR / Non-string in filter address list.
+    ("listunspent", [ None, None, [ 1 ] ], -32700,
+        "JSON value is not a string as expected"),
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Testnet address in filter address list.
+    ("listunspent", [ None, None, [ "mneqqWSAQCg6tTP4BUdnPDBRanFqaaryMM" ] ], -5,
+        "Invalid Bitcoin address: unknown version byte 111 for network mainnet"),
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Non-address string in filter address list.
+    ("listunspent", [ None, None, [ "non-address" ] ], -5,
+        "Invalid Bitcoin address: invalid base 58 character \"-\""),
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Presumably base58 non-address instead of address.
+    ("listunspent", [ None, None, [ "test" ] ], -5,
+        "Invalid Bitcoin address: invalid base 58 checksum for test"),
+    # Error case: RPC_INVALID_PARAMETER / Duplicate address in list.
+    ("listunspent", [ None, None, [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2",
+            "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2" ] ], -8,
+        "Invalid parameter, duplicated address: 1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2"),
+    # Error case: RPC_INVALID_PARAMETER / Duplicate address in list.
+    ("listunspent", [ None, None, None, False ], -8,
+        "Invalid parameter, not supported: include_unsafe"),
+
+    ## ``sendtoaddress``: ``address`` parameter
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Testnet version byte in address.
+    ("sendtoaddress", [ "mneqqWSAQCg6tTP4BUdnPDBRanFqaaryMM", 10000 ], -5,
+        "Invalid address: unknown version byte 111 for network mainnet"),
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Non-base58 address text.
+    ("sendtoaddress", [ "non-address", 10000 ], -5,
+        "Invalid address: invalid base 58 character \"-\""),
+    # Error case: RPC_INVALID_ADDRESS_OR_KEY / Presumably base58 non-address instead of address.
+    ("sendtoaddress", [ "test", 10000 ], -5,
+        "Invalid address: invalid base 58 checksum for test"),
+    # Error case: RPC_PARSE_ERROR / Integer instead of string for address.
+    ("sendtoaddress", [ 1, 10000 ], -32700,
+        "JSON value is not a string as expected"),
+    ## ``sendtoaddress``: ``amount`` parameter
+    # Error case: RPC_TYPE_ERROR / Negative amount to send.
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", -100 ], -3,
+        "Amount out of range"),
+    # Error case: RPC_TYPE_ERROR / Too large amount to send.
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 1e10 ], -3,
+        "Amount out of range"),
+    # Error case: RPC_TYPE_ERROR / Zero amount to send.
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 0 ], -3,
+        "Invalid amount for send"),
+    ## ``sendtoaddress``: ``comment`` parameter
+    # Error case: RPC_PARSE_ERROR / Integer instead of string for comment.
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000, 1 ], -32700,
+        "JSON value is not a string as expected"),
+    ## ``sendtoaddress``: ``commentto`` parameter
+    # Error case: RPC_PARSE_ERROR / Integer instead of string for comment to.
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000, "null", 1 ], -32700,
+        "JSON value is not a string as expected"),
+    ## ``sendtoaddress``: ``subtract_fee_from_amount`` parameter
+    # Error case: RPC_INVALID_PARAMETER / Enabled .
+    ("sendtoaddress", [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000, None, None, True ], -8,
+        "Subtract fee from amount not currently supported"),
+])
+@unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
+@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state2)
+@unittest.mock.patch('electrumsv.nodeapi.app_state')
+async def test_call_endpoints_failure_invalid_parameter_list_async(app_state_nodeapi: AppStateProxy,
+        app_state_wallet: AppStateProxy, app_state_keystore: AppStateProxy,
+        endpoint_name: str, parameter_list: list[Any], error_code: int, error_text: str,
+        server_tester: TestClient, funded_wallet_factory: Callable[[], Wallet]) -> None:
+    assert server_tester.app is not None
+    mock_server = server_tester.app["server"]
+    # Ensure the server does not require authorization to make a call.
+    mock_server._password = ""
+
+    wallet_password = "123456"
+    # The `funded_wallet_factory` fixture copies and opens the wallet and requires the password.
+    app_state_wallet.credentials.get_wallet_password = lambda wallet_path: wallet_password
+    app_state_keystore.credentials.get_wallet_password = lambda wallet_path: wallet_password
+
+    wallet = funded_wallet_factory()
+
+    wallets: dict[str, Wallet] = {}
+    irrelevant_path = os.urandom(32).hex()
+    wallets[irrelevant_path] = wallet
+    app_state_nodeapi.daemon.wallets = wallets
+
+    call_object = {
+        "id": 232,
+        "method": endpoint_name,
+        "params": parameter_list,
+    }
+    response = await server_tester.request(path="/", method="POST", json=call_object)
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    object = await response.json()
+    assert len(object) == 3
+    assert object["id"] == 232
+    assert object["result"] is None
+    assert len(object["error"]) == 2
+    assert object["error"]["code"] == error_code
+    assert object["error"]["message"] == error_text
+
+@unittest.mock.patch('electrumsv.nodeapi.app_state')
+async def test_call_getnewaddress_no_connected_blockchain_server_async(
+        app_state_nodeapi: AppStateProxy, server_tester: TestClient) -> None:
     assert server_tester.app is not None
     mock_server = server_tester.app["server"]
     # Ensure the server does not require authorization to make a call.
@@ -401,89 +588,8 @@ async def test_call_getnewaddress_no_available_server_async(app_state_nodeapi: A
     assert object["error"]["message"] == "No connected blockchain server"
 
 @unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_getnewaddress_no_account_async(app_state_nodeapi: AppStateProxy,
-        server_tester: TestClient) -> None:
-    assert server_tester.app is not None
-    mock_server = server_tester.app["server"]
-    # Ensure the server does not require authorization to make a call.
-    mock_server._password = ""
-
-    wallets: dict[str, Wallet] = {}
-    irrelevant_path = os.urandom(32).hex()
-    wallet = unittest.mock.Mock()
-    wallets[irrelevant_path] = wallet
-    app_state_nodeapi.daemon.wallets = wallets
-
-    server_state = unittest.mock.Mock(spec=ServerConnectionState)
-    def get_tip_filter_server_state() -> ServerConnectionState:
-        nonlocal server_state
-        return server_state
-    wallet.get_tip_filter_server_state.side_effect = get_tip_filter_server_state
-
-    # mock_account = unittest.mock.Mock(spec=StandardAccount)
-    def get_visible_accounts() -> list[StandardAccount]:
-        return []
-    wallet.get_visible_accounts.side_effect = get_visible_accounts
-
-    call_object = {
-        "id": 232,
-        "method": "getnewaddress",
-        "params": [],
-    }
-    response = await server_tester.request(path="/", method="POST", json=call_object)
-    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
-    object = await response.json()
-    assert len(object) == 3
-    assert object["id"] == 232
-    assert object["result"] is None
-    assert len(object["error"]) == 2
-    assert object["error"]["code"] == -4
-    assert object["error"]["message"] == "Ambiguous account (found 0, expected 1)"
-
-@unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_getnewaddress_too_many_accounts_async(app_state_nodeapi: AppStateProxy,
-        server_tester: TestClient) -> None:
-    assert server_tester.app is not None
-    mock_server = server_tester.app["server"]
-    # Ensure the server does not require authorization to make a call.
-    mock_server._password = ""
-
-    wallets: dict[str, Wallet] = {}
-    irrelevant_path = os.urandom(32).hex()
-    wallet = unittest.mock.Mock()
-    wallets[irrelevant_path] = wallet
-    app_state_nodeapi.daemon.wallets = wallets
-
-    server_state = unittest.mock.Mock(spec=ServerConnectionState)
-    def get_tip_filter_server_state() -> ServerConnectionState:
-        nonlocal server_state
-        return server_state
-    wallet.get_tip_filter_server_state.side_effect = get_tip_filter_server_state
-
-    mock_account1 = unittest.mock.Mock(spec=StandardAccount)
-    mock_account2 = unittest.mock.Mock(spec=StandardAccount)
-    def get_visible_accounts() -> list[StandardAccount]:
-        return [ mock_account1, mock_account2 ]
-    wallet.get_visible_accounts.side_effect = get_visible_accounts
-
-    call_object = {
-        "id": 232,
-        "method": "getnewaddress",
-        "params": [],
-    }
-    response = await server_tester.request(path="/", method="POST", json=call_object)
-    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
-    object = await response.json()
-    assert len(object) == 3
-    assert object["id"] == 232
-    assert object["result"] is None
-    assert len(object["error"]) == 2
-    assert object["error"]["code"] == -4
-    assert object["error"]["message"] == "Ambiguous account (found 2, expected 1)"
-
-@unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_getnewaddress_monitor_failure_no_server_async(app_state_nodeapi: AppStateProxy,
-        server_tester: TestClient) -> None:
+async def test_call_getnewaddress_remote_monitoring_failure_async(
+        app_state_nodeapi: AppStateProxy, server_tester: TestClient) -> None:
     assert server_tester.app is not None
     mock_server = server_tester.app["server"]
     # Ensure the server does not require authorization to make a call.
@@ -704,90 +810,158 @@ async def test_call_getnewaddress_success_async(app_state_nodeapi: AppStateProxy
     assert object["result"] == "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2"
     assert object["error"] is None
 
-@unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
-@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state2)
+@pytest.mark.parametrize("local_height,block_height,parameters,results", [
+    # Filter for an address and match it.
+    (100, 10, [ None, None, [ str(P2PKH_ADDRESS_1) ] ], [
+        {
+            "address": str(P2PKH_ADDRESS_1),
+            "amount": 0.00001000,
+            "confirmations": 90,
+            "safe": True,
+            "scriptPubKey": P2PKH_ADDRESS_1.to_script().to_hex(),
+            "solvable": True,
+            "spendable": True,
+            "txid": bitcoinx.hash_to_hex_str(FAKE_TRANSACTION_HASH),
+            "vout": 0,
+        }
+    ]),
+    # Filter for an address, filter out another and match nothing.
+    (100, 10, [ None, None, [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2" ] ], []),
+    # Filter for >=91 confirmations, filter out the 90 confirmations and match nothing.
+    (100, 10, [ 91, None ], []),
+    # Filter for >=90 confirmations, match the 90 confirmations entry.
+    (100, 10, [ 90, None ], [
+        {
+            "amount": 0.00001000,
+            "confirmations": 90,
+            "safe": True,
+            "scriptPubKey": P2PKH_ADDRESS_1.to_script().to_hex(),
+            "solvable": True,
+            "spendable": True,
+            "txid": bitcoinx.hash_to_hex_str(FAKE_TRANSACTION_HASH),
+            "vout": 0,
+        }
+    ]),
+    # Filter for <=90 confirmations, match the 90 confirmations entry.
+    (100, 10, [ None, 90 ], [
+        {
+            "amount": 0.00001000,
+            "confirmations": 90,
+            "safe": True,
+            "scriptPubKey": P2PKH_ADDRESS_1.to_script().to_hex(),
+            "solvable": True,
+            "spendable": True,
+            "txid": bitcoinx.hash_to_hex_str(FAKE_TRANSACTION_HASH),
+            "vout": 0,
+        }
+    ]),
+    # Filter for <=89 confirmations, filter out the 90 confirmations and match nothing.
+    (100, 10, [ None, 89 ], []),
+])
 @unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_sendtoaddress_failure_no_account_async(app_state_nodeapi: AppStateProxy,
-        app_state_wallet: AppStateProxy, app_state_keystore: AppStateProxy,
+async def test_call_listunspent_success_async(
+        app_state_nodeapi: AppStateProxy, local_height: int, block_height: int,
+        parameters: list[Any], results: list[dict[str, Any]],
         server_tester: TestClient) -> None:
     assert server_tester.app is not None
     mock_server = server_tester.app["server"]
     # Ensure the server does not require authorization to make a call.
     mock_server._password = ""
 
-    wallet_password = "password"
-    app_state_wallet.credentials.get_wallet_password = lambda wallet_path: wallet_password
-    app_state_keystore.credentials.get_wallet_password = lambda wallet_path: wallet_password
-    tmp_storage = cast(WalletStorage, MockStorage(wallet_password))
-    wallet = Wallet(tmp_storage)
-
     wallets: dict[str, Wallet] = {}
     irrelevant_path = os.urandom(32).hex()
+    wallet = unittest.mock.Mock()
     wallets[irrelevant_path] = wallet
     app_state_nodeapi.daemon.wallets = wallets
 
+    account = unittest.mock.Mock(spec=StandardAccount)
+    def get_visible_accounts() -> list[StandardAccount]:
+        nonlocal account
+        return [ account ]
+    wallet.get_visible_accounts.side_effect = get_visible_accounts
+
+    def get_transaction_outputs_with_key_and_tx_data(exclude_frozen: bool=True,
+            confirmed_only: bool|None=None, keyinstance_ids: list[int]|None=None) \
+                -> list[AccountTransactionOutputSpendableRowExtended]:
+        assert exclude_frozen is False
+        assert confirmed_only is True
+        assert keyinstance_ids is None
+        return [
+            AccountTransactionOutputSpendableRowExtended(FAKE_TRANSACTION_HASH, 0, 1000, None,
+                ScriptType.P2PKH, TransactionOutputFlag.NONE, 1, 1, DerivationType.BIP32_SUBPATH,
+                FAKE_DERIVATION_DATA2, TxFlags.STATE_SETTLED, FAKE_BLOCK_HASH)
+        ]
+    account.get_transaction_outputs_with_key_and_tx_data.side_effect = \
+        get_transaction_outputs_with_key_and_tx_data
+    account.is_watching_only = lambda: False
+
+    # Prepare the state so we can fake confirmations.
+    wallet.get_local_height = lambda: local_height
+
+    def lookup_header_for_hash(block_hash: bytes) -> tuple[bitcoinx.Header, bitcoinx.Chain]|None:
+        assert FAKE_BLOCK_HASH == block_hash
+        header = unittest.mock.Mock(spec=bitcoinx.Header)
+        header.height = block_height
+        chain = unittest.mock.Mock(spec=bitcoinx.Chain)
+        return header, chain
+    wallet.lookup_header_for_hash = lookup_header_for_hash
+
+    # Inject the public key / address for the row (we ignore its derivation data).
+    def get_public_keys_for_derivation(derivation_type: DerivationType,
+            derivation_data2: bytes|None) -> list[bitcoinx.PublicKey]:
+        assert derivation_type == DerivationType.BIP32_SUBPATH
+        assert derivation_data2 == FAKE_DERIVATION_DATA2
+        return [ PUBLIC_KEY_1 ]
+    account.get_public_keys_for_derivation.side_effect = \
+        get_public_keys_for_derivation
+
     call_object = {
         "id": 232,
-        "method": "sendtoaddress",
-        "params": [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000 ],
+        "method": "listunspent",
+        "params": parameters,
     }
     response = await server_tester.request(path="/", method="POST", json=call_object)
-    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert response.status == HTTPStatus.OK
     object = await response.json()
     assert len(object) == 3
     assert object["id"] == 232
-    assert object["result"] is None
-    assert len(object["error"]) == 2
-    assert object["error"]["code"] == -4 # WALLET_ERROR
-    assert object["error"]["message"] == "Ambiguous account (found 0, expected 1)"
+    assert object["result"] == results
+    assert object["error"] is None
 
-@unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
-@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state2)
 @unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_sendtoaddress_failure_too_many_accounts_async(app_state_nodeapi: AppStateProxy,
-        app_state_wallet: AppStateProxy, app_state_keystore: AppStateProxy,
-        server_tester: TestClient) -> None:
+async def test_call_listunspent_no_matches_success_async(
+        app_state_nodeapi: AppStateProxy, server_tester: TestClient) -> None:
     assert server_tester.app is not None
     mock_server = server_tester.app["server"]
     # Ensure the server does not require authorization to make a call.
     mock_server._password = ""
 
-    wallet_password = "password"
-    app_state_wallet.credentials.get_wallet_password = lambda wallet_path: wallet_password
-    app_state_keystore.credentials.get_wallet_password = lambda wallet_path: wallet_password
-    tmp_storage = cast(WalletStorage, MockStorage(wallet_password))
-    wallet = Wallet(tmp_storage)
-
     wallets: dict[str, Wallet] = {}
     irrelevant_path = os.urandom(32).hex()
+    wallet = unittest.mock.Mock()
     wallets[irrelevant_path] = wallet
     app_state_nodeapi.daemon.wallets = wallets
 
-    for i in range(2):
-        data = os.urandom(64)
-        coin = bitcoinx.BitcoinRegtest
-        xprv = bitcoinx.BIP32PrivateKey._from_parts(data[:32], data[32:], coin)
-        text_match = xprv.to_extended_key_string()
-        assert text_match is not None # typing bug
-        keystore = instantiate_keystore_from_text(KeystoreTextType.EXTENDED_PRIVATE_KEY,
-            text_match, wallet_password, derivation_text=None, passphrase="", watch_only=False)
-        wallet.create_account_from_keystore(
-            KeyStoreResult(AccountCreationType.IMPORTED, keystore))
+    account = unittest.mock.Mock(spec=StandardAccount)
+    def get_visible_accounts() -> list[StandardAccount]:
+        nonlocal account
+        return [ account ]
+    wallet.get_visible_accounts.side_effect = get_visible_accounts
+
+    account.get_transaction_outputs_with_key_and_tx_data.side_effect = lambda *args, **kwargs: []
 
     call_object = {
         "id": 232,
-        "method": "sendtoaddress",
-        "params": [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000 ],
+        "method": "listunspent",
+        "params": [],
     }
     response = await server_tester.request(path="/", method="POST", json=call_object)
-    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert response.status == HTTPStatus.OK
     object = await response.json()
     assert len(object) == 3
     assert object["id"] == 232
-    assert object["result"] is None
-    assert len(object["error"]) == 2
-    assert object["error"]["code"] == -4 # WALLET_ERROR
-    assert object["error"]["message"] == "Ambiguous account (found 2, expected 1)"
+    assert object["result"] == []
+    assert object["error"] is None
 
 # The keystore app_state is required for credential caching by wallet logic.
 @unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
@@ -844,63 +1018,10 @@ async def test_call_sendtoaddress_walletpassphrase_required_async(app_state_node
     assert object["error"]["message"] == "Error: Please enter the wallet passphrase with " \
         "walletpassphrase first."
 
-# The keystore app_state is required for credential caching by wallet logic.
 @unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
 @unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state2)
 @unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_sendtoaddress_failure_no_message_box_server_async(
-        app_state_nodeapi: AppStateProxy, app_state_wallet: AppStateProxy,
-        app_state_keystore: AppStateProxy, server_tester: TestClient) -> None:
-    assert server_tester.app is not None
-    mock_server = server_tester.app["server"]
-    # Ensure the server does not require authorization to make a call.
-    mock_server._password = ""
-
-    wallet_password = "password"
-    # Setup: ensure the `Wallet` instantiation code can find the password when instantiating the
-    #     petty cash account (and any other applicable points).
-    app_state_wallet.credentials.get_wallet_password = lambda wallet_path: wallet_password
-    tmp_storage = cast(WalletStorage, MockStorage(wallet_password))
-    wallet = Wallet(tmp_storage)
-
-    # Setup: create one account in the wallet.
-    data = os.urandom(64)
-    coin = bitcoinx.BitcoinRegtest
-    xprv = bitcoinx.BIP32PrivateKey._from_parts(data[:32], data[32:], coin)
-    text_match = xprv.to_extended_key_string()
-    assert text_match is not None # typing bug
-    keystore = instantiate_keystore_from_text(KeystoreTextType.EXTENDED_PRIVATE_KEY,
-        text_match, wallet_password, derivation_text=None, passphrase="", watch_only=False)
-    wallet.create_account_from_keystore(
-        KeyStoreResult(AccountCreationType.IMPORTED, keystore))
-
-    wallets: dict[str, Wallet] = {}
-    irrelevant_path = os.urandom(32).hex()
-    wallets[irrelevant_path] = wallet
-    app_state_nodeapi.daemon.wallets = wallets
-
-    # Setup: The nodeapi checks the password is present before our failure point.
-    app_state_nodeapi.credentials.get_wallet_password = lambda wallet_path: wallet_password
-
-    call_object = {
-        "id": 232,
-        "method": "sendtoaddress",
-        "params": [ "1Ey71nXGETcEvzpQyhwEaPn7UdGmDyrGF2", 10000 ],
-    }
-    response = await server_tester.request(path="/", method="POST", json=call_object)
-    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
-    object = await response.json()
-    assert len(object) == 3
-    assert object["id"] == 232
-    assert object["result"] is None
-    assert len(object["error"]) == 2
-    assert object["error"]["code"] == -4 # WALLET_ERROR
-    assert object["error"]["message"] == "No configured peer channel server"
-
-@unittest.mock.patch('electrumsv.keystore.app_state', new_callable=_create_mock_app_state2)
-@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state2)
-@unittest.mock.patch('electrumsv.nodeapi.app_state')
-async def test_call_sendtoaddress_failure_invalid_parameters_async(
+async def test_call_sendtoaddress_failure_no_configured_peer_channel_server_async(
         app_state_nodeapi: AppStateProxy,app_state_wallet: AppStateProxy,
         app_state_keystore: AppStateProxy, server_tester: TestClient,
         funded_wallet_factory: Callable[[], Wallet]) -> None:

--- a/electrumsv/tests/test_wallet.py
+++ b/electrumsv/tests/test_wallet.py
@@ -791,6 +791,8 @@ async def test_transaction_import_removal(mock_app_state, tmp_storage) -> None:
     # Ensure that the keys used by the transaction are present to be linked to.
     account.derive_new_keys_until(RECEIVING_SUBPATH + (2,))
 
+    maturity_height = 100000
+
     db_context = tmp_storage.get_db_context()
     db = db_context.acquire_connection()
     try:
@@ -810,10 +812,10 @@ async def test_transaction_import_removal(mock_app_state, tmp_storage) -> None:
         assert tv_rows1[0].account_id == account.get_id()
         assert tv_rows1[0].total == 1044113
 
-        balance = db_functions.read_account_balance(db_context, account.get_id())
+        balance = db_functions.read_account_balance(db_context, account.get_id(), maturity_height)
         assert balance == WalletBalance(0, 0, 0, 1044113)
 
-        balance = db_functions.read_wallet_balance(db_context)
+        balance = db_functions.read_wallet_balance(db_context, maturity_height)
         assert balance == WalletBalance(0, 0, 0, 1044113)
 
         tx_2 = Transaction.from_hex(tx_hex_spend)
@@ -829,10 +831,10 @@ async def test_transaction_import_removal(mock_app_state, tmp_storage) -> None:
         assert tv_rows2[0].total == -1044113
 
         # Check the transaction balance.
-        balance = db_functions.read_account_balance(db_context, account.get_id())
+        balance = db_functions.read_account_balance(db_context, account.get_id(), maturity_height)
         assert balance == WalletBalance(0, 0, 0, 0)
 
-        balance = db_functions.read_wallet_balance(db_context)
+        balance = db_functions.read_wallet_balance(db_context, maturity_height)
         assert balance == WalletBalance(0, 0, 0, 0)
 
         # Verify all the transaction outputs are present and are linked to spending inputs.

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -505,10 +505,13 @@ class AbstractAccount:
         return cast(str, private_key.to_WIF())
 
     def get_frozen_balance(self) -> WalletBalance:
-        return self._wallet.data.read_account_balance(self._id, TransactionOutputFlag.FROZEN)
+        maturity_height = self._wallet.get_local_height() - 100
+        return self._wallet.data.read_account_balance(self._id, maturity_height,
+            TransactionOutputFlag.FROZEN)
 
     def get_balance(self) -> WalletBalance:
-        return self._wallet.data.read_account_balance(self._id)
+        maturity_height = self._wallet.get_local_height() - 100
+        return self._wallet.data.read_account_balance(self._id, maturity_height)
 
     def get_key_list(self, keyinstance_ids: list[int]|None=None) -> list[KeyListRow]:
         return self._wallet.data.read_key_list(self._id, keyinstance_ids)
@@ -526,20 +529,19 @@ class AbstractAccount:
                 -> Sequence[AccountTransactionOutputSpendableRow]:
         if confirmed_only is None:
             confirmed_only = cast(bool, app_state.config.get('confirmed_only', False))
+        maturity_height = self._wallet.get_local_height() - 100 if mature else None
         return self._wallet.data.read_account_transaction_outputs_with_key_data(self._id,
-            confirmed_only=confirmed_only, exclude_immature=mature,
+            confirmed_only=confirmed_only, maturity_height=maturity_height,
             exclude_frozen=exclude_frozen, keyinstance_ids=keyinstance_ids)
 
     def get_transaction_outputs_with_key_and_tx_data(self, exclude_frozen: bool=True,
-            mature: bool=True, confirmed_only: bool|None=None,
-            keyinstance_ids: list[int]|None=None) \
+            confirmed_only: bool|None=None, keyinstance_ids: list[int]|None=None) \
                 -> list[AccountTransactionOutputSpendableRowExtended]:
         if confirmed_only is None:
             confirmed_only = cast(bool, app_state.config.get('confirmed_only', False))
-        mature_height = self._wallet.get_local_height() if mature else None
         return self._wallet.data.read_account_transaction_outputs_with_key_and_tx_data(self._id,
-            confirmed_only=confirmed_only, mature_height=mature_height,
-            exclude_frozen=exclude_frozen, keyinstance_ids=keyinstance_ids)
+            confirmed_only=confirmed_only, exclude_frozen=exclude_frozen,
+            keyinstance_ids=keyinstance_ids)
 
     def get_extended_input_for_spendable_output(self, row: TransactionOutputSpendableProtocol) \
             -> XTxInput:
@@ -1819,12 +1821,12 @@ class WalletDataAccess:
 
     # Accounts.
 
-    def read_account_balance(self, account_id: int,
+    def read_account_balance(self, account_id: int, maturity_height: int,
             txo_flags: TransactionOutputFlag=TransactionOutputFlag.NONE,
             txo_mask: TransactionOutputFlag=TransactionOutputFlag.SPENT,
             exclude_frozen: bool=True) -> WalletBalance:
         return db_functions.read_account_balance(self._db_context,
-            account_id, txo_flags, txo_mask, exclude_frozen)
+            account_id, maturity_height, txo_flags, txo_mask, exclude_frozen)
 
     def update_account_names(self, entries: Iterable[tuple[str, int]]) \
             -> concurrent.futures.Future[None]:
@@ -2380,20 +2382,19 @@ class WalletDataAccess:
     # Transaction outputs.
 
     def read_account_transaction_outputs_with_key_data(self, account_id: int,
-            confirmed_only: bool=False, exclude_immature: bool=False,
+            confirmed_only: bool=False, maturity_height: int|None=None,
             exclude_frozen: bool=False, keyinstance_ids: list[int]|None=None) \
                 -> list[AccountTransactionOutputSpendableRow]:
         return db_functions.read_account_transaction_outputs_with_key_data(
-            self._db_context, account_id, confirmed_only, exclude_immature,
+            self._db_context, account_id, confirmed_only, maturity_height,
             exclude_frozen, keyinstance_ids)
 
     def read_account_transaction_outputs_with_key_and_tx_data(self, account_id: int,
-            confirmed_only: bool=False, mature_height: int|None=None,
-            exclude_frozen: bool=False, keyinstance_ids: list[int]|None=None) \
+            confirmed_only: bool=False, exclude_frozen: bool=False,
+            keyinstance_ids: list[int]|None=None) \
                 -> list[AccountTransactionOutputSpendableRowExtended]:
         return db_functions.read_account_transaction_outputs_with_key_and_tx_data(
-            self._db_context, account_id, confirmed_only, mature_height,
-                exclude_frozen, keyinstance_ids)
+            self._db_context, account_id, confirmed_only, exclude_frozen, keyinstance_ids)
 
     def read_spent_outputs_to_monitor(self) -> list[OutputSpend]:
         return db_functions.read_spent_outputs_to_monitor(self._db_context)

--- a/examples/applications/restapi/handler_utils.py
+++ b/examples/applications/restapi/handler_utils.py
@@ -446,8 +446,7 @@ class ExtendedHandlerUtils:
         return accounts
 
     def _coin_state_dto(self, account) -> Dict[str, Any]:
-        all_coins = account.get_transaction_outputs_with_key_and_tx_data(confirmed_only=False,
-            mature=False)
+        all_coins = account.get_transaction_outputs_with_key_and_tx_data(confirmed_only=False)
         unmatured_coins = []
         cleared_coins = []
         settled_coins = []


### PR DESCRIPTION
- There are several elements that are not 100% compatible, these are documented and a later pass can go through and finalise acceptable incompatibilities/ensure correctness.
- Remove obsolete `COINBASE_IMMATURE` transaction output flag that was apparently partially removed.
  - Maturity filtering is now done by passing in the maturity height to the DB queries.
- Documentation for `listunspent`.
  - All endpoint parameters now feature their parameter name, as this important for users who use an object to pass them rather than the list.
- Unit tests for `listunspent`.
  - The unit tests were refactored to do more common parameterisation to reduce common code while avoiding the lack of clarity that comes from abstraction.