### PR TITLE
Fix a few details about listunspent.

### DIFF
--- a/docs/standalone/building-on-electrumsv/node-wallet-api.rst
+++ b/docs/standalone/building-on-electrumsv/node-wallet-api.rst
@@ -657,21 +657,23 @@ fields:
 - ``address``: Only present if this address was included in the ``addresses`` array and filtered on.
 
 For example, passing ``"params": { "addresses": ["mmne6bSrjwRZk16Y7TkwrrWysiUXZfd9ZY"] }`` returns:
-```
-[
-    {
-        "txid": "023d74ad33de138ef8b98cfd9950dc1b69c5855146e6a64f502a5be92fd626af",
-        "vout": 0,
-        "scriptPubKey":"76a91444c838328b3b9ab6e0ee1f021e281c46fb2804ca88ac",
-        "amount": 50.00000553,
-        "confirmations": 2,
-        "spendable": false,
-        "solvable": true,
-        "safe": true,
-        "address": "mmne6bSrjwRZk16Y7TkwrrWysiUXZfd9ZY"
-    }
-]
-```
+
+.. code-block:: js
+
+    [
+        {
+            "txid": "023d74ad33de138ef8b98cfd9950dc1b69c5855146e6a64f502a5be92fd626af",
+            "vout": 0,
+            "scriptPubKey":"76a91444c838328b3b9ab6e0ee1f021e281c46fb2804ca88ac",
+            "amount": 50.00000553,
+            "confirmations": 2,
+            "spendable": false,
+            "solvable": true,
+            "safe": true,
+            "address": "mmne6bSrjwRZk16Y7TkwrrWysiUXZfd9ZY"
+        }
+    ]
+
 Note that in this case the UTXO is an unspent immature coinbase output, and is not spendable.
 
 **Incompatibilities:**

--- a/electrumsv/nodeapi.py
+++ b/electrumsv/nodeapi.py
@@ -53,7 +53,7 @@ import threading
 import time
 from types import NoneType
 from typing import Any, Awaitable, Callable, cast, TYPE_CHECKING
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import TypedDict
 
 from aiohttp import web
 # NOTE(typing) `cors_middleware` is not explicitly exported, so mypy strict fails. No idea.
@@ -666,7 +666,6 @@ async def jsonrpc_listunspent_async(request: web.Request, request_id: RequestIdT
         safe: bool
 
     confirmed_only = minimum_confirmations > 0
-    can_spend = not account.is_watching_only()
     wallet_height = wallet.get_local_height()
     results: list[NodeUnspentOutputDict] = []
     for utxo_data in account.get_transaction_outputs_with_key_and_tx_data(

--- a/electrumsv/nodeapi.py
+++ b/electrumsv/nodeapi.py
@@ -656,9 +656,7 @@ async def jsonrpc_listunspent_async(request: web.Request, request_id: RequestIdT
         txid: str
         vout: int
 
-        # The address BUT ONLY IF the caller is filtering for it specifically.
-        address: NotRequired[str]
-
+        address: str
         # The UTXO locking script.
         scriptPubKey: str
         amount: float


### PR DESCRIPTION
- Documentation formatting, where it was using markdown not ReST.
- Remove incorrect `address` typing, given it is required in the result.