### PR TITLE
3.10.6 supposedly includes a change to how `.rowcount` is done, where…

### DIFF
--- a/electrumsv/tests/test_wallet_database_tables.py
+++ b/electrumsv/tests/test_wallet_database_tables.py
@@ -1649,6 +1649,19 @@ def test_table_peer_channels_CRUD(db_context: DatabaseContext) -> None:
     read_row = read_rows[0]
     assert read_row == created_row
 
+    future = db_context.post_to_thread(db_functions.update_server_peer_channel_write,
+        None, "NOT A REAL URL", ServerPeerChannelFlag.NONE, peer_channel_id, [])
+    updated_row = future.result()
+    assert updated_row.remote_channel_id is None
+    assert updated_row.remote_url == "NOT A REAL URL"
+    assert updated_row.peer_channel_flags == ServerPeerChannelFlag.NONE
+
+    # Check that a read produces the same result as the update.
+    read_rows = db_functions.read_server_peer_channels(db_context, server_id)
+    assert len(read_rows) == 1
+    read_row = read_rows[0]
+    assert read_row == updated_row
+
 
 def test_table_peer_channel_messages_CRUD(db_context: DatabaseContext) -> None:
     date_created = 1


### PR DESCRIPTION
… `.rowcount` is set by explicit row fetches (as per Python developer 'wontfix' response). This goes over all `RETURNING` usage where we do not fetch the rows, and brings these `.rowcount` calls in line with the breaking Python 3.10.6 change. The `close_paid_payment_requests` call was already unit tested, a unit test has been added for `update_server_peer_channel_write`.