### PR TITLE
This includes three fixes to header handling.

### DIFF
--- a/electrumsv/cached_headers.py
+++ b/electrumsv/cached_headers.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from bitcoinx import CheckPoint, Headers, Network
 
+from .constants import EMPTY_HASH
 from .logs import logs
 
 
@@ -63,14 +64,11 @@ def read_cached_headers(coin: Network, file_path: str, checkpoint: CheckPoint) -
                         #     attributes are missing. This data works for the same deterministic
                         #     Python version and dependency installation, just not on my computer.
                         #     This is very likely a bug in pickle that is trigged by my arch.
-                        logger.error("Error deserialising chain tip header (chain first height: "
-                            "%d); forceably replacing it as a workaround", chain.first_height)
-                        header_index = chain._header_indices[-1]
-                        chain.tip = headers.network.deserialized_header(
-                            headers._storage[header_index], -1)
-                        prev_header, prev_chain = headers.lookup(chain.tip.prev_hash)
-                        chain.tip.height = prev_header.height + 1
-                    else:
+                        logger.error("Error deserialising tip header (chain first height: %d)",
+                            chain.first_height)
+                        raise
+
+                    if chain.tip.prev_hash != EMPTY_HASH:
                         # Validate that the tip deserialised well enough to have the right height.
                         prev_header, prev_chain = headers.lookup(chain.tip.prev_hash)
                         assert chain.tip.height == prev_header.height + 1


### PR DESCRIPTION
- Remove the ill conceived workaround for the bug in Python pickling when deserialising headers. The reason to avoid this workaround and others like it is we have no idea if we are repairing the only problem that could be caused by this bug. Better to classify it as not our problem and blame upstream Python.
- Attempt to address the long standing problem with headers file corruption (see Github issue #1043). The Python mmap documentation clearly states that `flush` must be called and for some reason we do not call it. Now we call both `flush` and `close` on the underlying mmap object. It remains to be seen if this will fix the problem, but exiting does not error so it does not hurt.