### PR TITLE
Node API backlog task creation preparation WRT get/list transaction m…

### DIFF
--- a/electrumsv/gui/qt/app.py
+++ b/electrumsv/gui/qt/app.py
@@ -247,10 +247,10 @@ class SVApplication(QApplication):
 
     def _register_wallet_events(self, wallet: Wallet) -> None:
         # NOTE(typing) Some typing nonsense about not being able to assign to a method.
-        wallet.contacts._on_contact_added = self._on_contact_added # type: ignore[assignment]
-        wallet.contacts._on_contact_removed = self._on_contact_removed # type: ignore[assignment]
-        wallet.contacts._on_identity_added = self._on_identity_added # type: ignore[assignment]
-        wallet.contacts._on_identity_removed = self._on_identity_removed # type: ignore[assignment]
+        wallet.contacts._on_contact_added = self._on_contact_added # type: ignore[method-assign]
+        wallet.contacts._on_contact_removed = self._on_contact_removed # type: ignore[method-assign]
+        wallet.contacts._on_identity_added = self._on_identity_added # type: ignore[method-assign]
+        wallet.contacts._on_identity_removed=self._on_identity_removed # type: ignore[method-assign]
 
     def _on_identity_added(self, contact: ContactEntry, identity: ContactIdentity) -> None:
         self.identity_added_signal.emit(contact, identity)

--- a/electrumsv/gui/qt/key_dialog.py
+++ b/electrumsv/gui/qt/key_dialog.py
@@ -113,7 +113,7 @@ class KeyDialog(WindowModalDialog):
         self._history_list = history_list.HistoryList(self._main_window, self._main_window)
         self._history_list._on_account_change(self._account_id, self._account, False)
         # NOTE(typing) I have no idea why we are suddenly getting "Cannot assign to a method"
-        self._history_list.get_domain = self.get_domain # type: ignore[assignment]
+        self._history_list.get_domain = self.get_domain # type: ignore[method-assign]
         vbox.addWidget(self._history_list)
 
         vbox.addLayout(Buttons(CloseButton(self)))

--- a/electrumsv/gui/qt/password_dialog.py
+++ b/electrumsv/gui/qt/password_dialog.py
@@ -102,7 +102,7 @@ class PasswordLineEdit(QWidget):
         # Pass-throughs
         self.key_event_signal = self.pw.key_event_signal
         self.returnPressed = self.pw.returnPressed
-        self.setFocus = self.pw.setFocus # type: ignore[assignment]
+        self.setFocus = self.pw.setFocus # type: ignore[method-assign]
         self.setMaxLength = self.pw.setMaxLength
         self.setPlaceholderText = self.pw.setPlaceholderText
         self.setText = self.pw.setText

--- a/electrumsv/gui/qt/util.py
+++ b/electrumsv/gui/qt/util.py
@@ -939,7 +939,7 @@ class ButtonsTextEdit(QPlainTextEdit, ButtonsWidget):
     def __init__(self, text: Optional[str]=None) -> None:
         QPlainTextEdit.__init__(self, text)
         self.setText = self.setPlainText
-        self.text = self.toPlainText # type: ignore[assignment]
+        self.text = self.toPlainText # type: ignore[method-assign]
         self.buttons: List[QAbstractButton] = []
 
     def resizeEvent(self, event: QResizeEvent) -> None:

--- a/electrumsv/tests/data/wallets/26_regtest_standard_mining_with_mature_and_immature_coins_history_full.json
+++ b/electrumsv/tests/data/wallets/26_regtest_standard_mining_with_mature_and_immature_coins_history_full.json
@@ -11,17 +11,6 @@
         "script_pubkey_hex": "76a914b4ebd9eecb9097eb9cf56c25ce84aa8bf9abcf1888ac"
     },
     {
-        "txo_index": 0,
-        "is_mine": true,
-        "value": 7878800,
-        "block_height": 115,
-        "block_position": 2,
-        "date_created": 1666735880,
-        "tx_id": "49250a55f59e2bbf1b0615508c2d586c1336d7c0c6d493f02bc82349fabe6609",
-        "block_id": null,
-        "script_pubkey_hex": "76a9141b425fae31aea151a307052c776606870a7bd06488ac"
-    },
-    {
         "txo_index": 1,
         "is_mine": false,
         "value": -112121000,
@@ -77,28 +66,6 @@
         "script_pubkey_hex": "76a914b09fd19a150e770833bd4970ab53f3a01a60c2ce88ac"
     },
     {
-        "txo_index": 0,
-        "is_mine": true,
-        "value": 68999800,
-        "block_height": 113,
-        "block_position": 1,
-        "date_created": 1666735879,
-        "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
-        "block_id": null,
-        "script_pubkey_hex": "76a914f22717cbba56f68907ccf1b210f74ca16343804788ac"
-    },
-    {
-        "txo_index": 1,
-        "is_mine": true,
-        "value": 120000000,
-        "block_height": 113,
-        "block_position": 1,
-        "date_created": 1666735879,
-        "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
-        "block_id": null,
-        "script_pubkey_hex": "76a914de8d5d06e2cf67c42faa2d91e3b7794301848d7c88ac"
-    },
-    {
         "txo_index": 2,
         "is_mine": false,
         "value": -131000000,
@@ -108,5 +75,38 @@
         "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
         "block_id": null,
         "script_pubkey_hex": "52210310274914ab9e07b507eb13cde158320450e4f6d6508645b1e06069976802a9332103308c167165296c5253c798fe11820a8c3b4245e2d252c9d8c25f6bbf98a9bfa052ae"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 5000000316,
+        "block_height": 113,
+        "block_position": 0,
+        "date_created": 1666735880,
+        "tx_id": "b50efbc7b29d1943ca54f90213845c9bf29543f176be52df73d4eefcdd658c53",
+        "block_id": null,
+        "script_pubkey_hex": "76a91411e4d512620a42f4c3e376dfaf695bd11d71011488ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": false,
+        "value": -110000000,
+        "block_height": 112,
+        "block_position": 1,
+        "date_created": 1666735879,
+        "tx_id": "88c92bb09626c7d505ed861ae8fa7e7aaab5b816fc517eac7a8a6c7f28b1b210",
+        "block_id": null,
+        "script_pubkey_hex": "21032fcb2fa3280cfdc0ffd527b40f592f5ae80556f2c9f98a649f1b1af13f332fdbac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 5000000300,
+        "block_height": 112,
+        "block_position": 0,
+        "date_created": 1666735880,
+        "tx_id": "79c512b6c62056227a3ebbda40011c8ac262a34987525d41932ecb668e5c8f26",
+        "block_id": null,
+        "script_pubkey_hex": "76a914dd5f97d12400d71ce6dd570449688ecb2e7d70cc88ac"
     }
 ]

--- a/electrumsv/tests/data/wallets/26_regtest_standard_mining_with_mature_and_immature_coins_history_full.json
+++ b/electrumsv/tests/data/wallets/26_regtest_standard_mining_with_mature_and_immature_coins_history_full.json
@@ -1,0 +1,112 @@
+[
+    {
+        "txo_index": 1,
+        "is_mine": true,
+        "value": 25000000,
+        "block_height": 115,
+        "block_position": 3,
+        "date_created": 1666735879,
+        "tx_id": "1afaa1c87ca193480c9aa176f08af78e457e8b8415c71697eded1297ed953db6",
+        "block_id": null,
+        "script_pubkey_hex": "76a914b4ebd9eecb9097eb9cf56c25ce84aa8bf9abcf1888ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 7878800,
+        "block_height": 115,
+        "block_position": 2,
+        "date_created": 1666735880,
+        "tx_id": "49250a55f59e2bbf1b0615508c2d586c1336d7c0c6d493f02bc82349fabe6609",
+        "block_id": null,
+        "script_pubkey_hex": "76a9141b425fae31aea151a307052c776606870a7bd06488ac"
+    },
+    {
+        "txo_index": 1,
+        "is_mine": false,
+        "value": -112121000,
+        "block_height": 115,
+        "block_position": 2,
+        "date_created": 1666735880,
+        "tx_id": "49250a55f59e2bbf1b0615508c2d586c1336d7c0c6d493f02bc82349fabe6609",
+        "block_id": null,
+        "script_pubkey_hex": "a9148153746f08c792c37267b01524d227bd39741ebf87"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 259999847,
+        "block_height": 115,
+        "block_position": 1,
+        "date_created": 1666735880,
+        "tx_id": "47f3f47a256d70950ff5690ea377c24464310489e3f54d01b817dd0088f0a095",
+        "block_id": null,
+        "script_pubkey_hex": "76a9141a88fa0d13121861c8f06af6f15fdb72c242b18f88ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 5000000553,
+        "block_height": 115,
+        "block_position": 0,
+        "date_created": 1666735880,
+        "tx_id": "023d74ad33de138ef8b98cfd9950dc1b69c5855146e6a64f502a5be92fd626af",
+        "block_id": null,
+        "script_pubkey_hex": "76a91444c838328b3b9ab6e0ee1f021e281c46fb2804ca88ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 5000000000,
+        "block_height": 114,
+        "block_position": 0,
+        "date_created": 1666735880,
+        "tx_id": "7776689d6d8528d9e55d7cf4b6b037fbeb3163b4a537fe82ebf417003f7f5db2",
+        "block_id": null,
+        "script_pubkey_hex": "76a914a4b822c41dfea4375686a1a42e4c7555177b68aa88ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 130999884,
+        "block_height": 113,
+        "block_position": 2,
+        "date_created": 1666735880,
+        "tx_id": "0120eae6dc11459fe79fbad26f998f4f8c5b75fa6f0fff5b0beca4f35ea7d721",
+        "block_id": null,
+        "script_pubkey_hex": "76a914b09fd19a150e770833bd4970ab53f3a01a60c2ce88ac"
+    },
+    {
+        "txo_index": 0,
+        "is_mine": true,
+        "value": 68999800,
+        "block_height": 113,
+        "block_position": 1,
+        "date_created": 1666735879,
+        "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
+        "block_id": null,
+        "script_pubkey_hex": "76a914f22717cbba56f68907ccf1b210f74ca16343804788ac"
+    },
+    {
+        "txo_index": 1,
+        "is_mine": true,
+        "value": 120000000,
+        "block_height": 113,
+        "block_position": 1,
+        "date_created": 1666735879,
+        "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
+        "block_id": null,
+        "script_pubkey_hex": "76a914de8d5d06e2cf67c42faa2d91e3b7794301848d7c88ac"
+    },
+    {
+        "txo_index": 2,
+        "is_mine": false,
+        "value": -131000000,
+        "block_height": 113,
+        "block_position": 1,
+        "date_created": 1666735879,
+        "tx_id": "479833ff49d1000cd6f9d23a88924d22eaeae8b9d543e773d7420c2bbfd73fe2",
+        "block_id": null,
+        "script_pubkey_hex": "52210310274914ab9e07b507eb13cde158320450e4f6d6508645b1e06069976802a9332103308c167165296c5253c798fe11820a8c3b4245e2d252c9d8c25f6bbf98a9bfa052ae"
+    }
+]

--- a/electrumsv/tests/test_wallet.py
+++ b/electrumsv/tests/test_wallet.py
@@ -38,8 +38,8 @@ from electrumsv.wallet_database.types import AccountRow, KeyInstanceRow, MerkleP
     WalletBalance
 from electrumsv.wallet_support.keys import get_pushdata_hash_for_keystore_key_data
 
-from .util import _create_mock_app_state, mock_headers, MockStorage, PasswordToken, setup_async, \
-    tear_down_async, TEST_WALLET_PATH
+from .util import _create_mock_app_state, mock_headers, MockStorage, PasswordToken, \
+    read_testdata_for_wallet, setup_async, tear_down_async, TEST_WALLET_PATH
 from ..network_support.types import ServerConnectionState
 
 T1 = TypeVar("T1")
@@ -488,7 +488,7 @@ class TestLegacyWalletCreation:
 
 
 @pytest.mark.parametrize("storage_info",
-    get_categorised_files2(TEST_WALLET_PATH, exclude_suffix="_testdata.json"))
+    get_categorised_files2(TEST_WALLET_PATH, exclude_suffix=".json"))
 @unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state)
 def test_legacy_wallet_loading(mock_wallet_app_state, storage_info: WalletStorageInfo,
         caplog) -> None:
@@ -629,9 +629,6 @@ def check_specific_wallets(wallet: Wallet, password: str, storage_info: WalletSt
     but we'll check them all just to be sure, and should consider varying the stored data
     to ensure more migration cases are checked.
     """
-    testdata_filename = storage_info.wallet_filepath +"_testdata.json"
-    assert os.path.exists(testdata_filename)
-
     transaction_rows = db_functions.UNITTEST_read_transactions(wallet.data._db_context)
     testdata_transactions: list[dict] = []
     transaction_hashes: list[bytes] = []
@@ -717,13 +714,8 @@ def check_specific_wallets(wallet: Wallet, password: str, storage_info: WalletSt
         "transactions": sorted(testdata_transactions, key=lambda t3: t3["transaction_id"]),
     }
 
-    if True:
-        with open(testdata_filename, "r") as f:
-            existing_testdata_object = json.load(f)
-        assert existing_testdata_object == testdata_object
-    else:
-        with open(testdata_filename, "w") as f:
-            json.dump(testdata_object, f, indent=4)
+    existing_testdata_object = read_testdata_for_wallet(storage_info.wallet_filepath, "testdata")
+    assert existing_testdata_object == testdata_object
 
 
 # class TestImportedPrivkeyAccount:

--- a/electrumsv/tests/test_wallet_database_functions.py
+++ b/electrumsv/tests/test_wallet_database_functions.py
@@ -1,0 +1,75 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest.mock
+
+from bitcoinx import hash_to_hex_str
+
+from electrumsv.constants import AccountFlags
+from electrumsv.networks import Net, SVMainnet, SVRegTestnet
+from electrumsv.storage import WalletStorage
+from electrumsv.wallet_database import functions as db_functions
+
+from .util import _create_mock_app_state, mock_headers, PasswordToken, read_testdata_for_wallet, \
+    TEST_WALLET_PATH
+
+
+# TODO(techinical-debt) We need to upgrade the test wallet with all the transactions to the current
+# database migration. That adds a bit of boilerplate. If we preupgraded all the test wallets and
+# stored them somewhere and just copied the files, we'd be able to just open it with SQLite
+# directory and without the layers of abstraction and the boilerplate.
+
+@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state)
+def test_read_history_for_outputs(mock_wallet_app_state) -> None:
+    """
+    Verify that the SQL for the `read_history_for_outputs` database function is correct.
+    """
+    password = "123456"
+    password_token = PasswordToken(password)
+    mock_wallet_app_state.credentials.get_wallet_password = lambda wallet_path: password
+
+    # Make sure we do not overwrite the original wallet database.
+    wallet_filename = "26_regtest_standard_mining_with_mature_and_immature_coins.sqlite"
+    temp_dir = tempfile.mkdtemp()
+    source_wallet_path = os.path.join(TEST_WALLET_PATH, wallet_filename)
+    wallet_path = os.path.join(temp_dir, wallet_filename)
+    shutil.copyfile(source_wallet_path, wallet_path)
+
+    storage = WalletStorage(wallet_path)
+
+    with unittest.mock.patch(
+        "electrumsv.wallet_database.migrations.migration_0029_reference_server.app_state") \
+        as migration29_app_state:
+            migration29_app_state.headers = mock_headers()
+            storage.upgrade(True, password_token)
+
+    # SECTION: The test preparation.
+    db_context = storage.get_db_context()
+    assert db_context is not None
+
+    account_id = -1
+    for account_row in db_functions.read_accounts(db_context):
+         if account_row.flags == AccountFlags.NONE:
+              account_id = account_row.account_id
+              break
+    assert account_id != -1
+
+    Net.set_to(SVRegTestnet)
+    try:
+        # SECTION: The actual test code.
+        testdata_object: list[dict] = []
+        for db_row in db_functions.read_history_for_outputs(db_context, account_id):
+            entry_dict = db_row._asdict()
+            # JSON does not support embedded byte data so we convert to hexl; canonical hex
+            # byte order in the case of transaction and block hashes.
+            entry_dict["tx_id"] = hash_to_hex_str(entry_dict.pop("tx_hash"))
+            block_hash = entry_dict.pop("block_hash")
+            entry_dict["block_id"] = hash_to_hex_str(block_hash) if block_hash is not None else None
+            entry_dict["script_pubkey_hex"] = entry_dict.pop("script_pubkey_bytes").hex()
+            testdata_object.append(entry_dict)
+
+        existing_testdata_object = read_testdata_for_wallet(source_wallet_path, "history_full")
+        assert testdata_object == existing_testdata_object
+    finally:
+        Net.set_to(SVMainnet)

--- a/electrumsv/tests/util.py
+++ b/electrumsv/tests/util.py
@@ -1,6 +1,6 @@
-
 from __future__ import annotations
 import asyncio
+import json
 import os
 from typing import Any, Coroutine, NoReturn, TypeVar
 import unittest.mock
@@ -140,3 +140,25 @@ def _create_mock_app_state2() -> unittest.mock.MagicMock:
     mock.async_.spawn_and_wait = _spawn_and_wait
     return mock
 
+def read_testdata_for_wallet(wallet_path: str, context_text: str, *,
+        testdata_object_for_write: dict|None=None) -> dict:
+    """
+    Parameters:
+        - `wallet_path`: The full path of the wallet. The test data file will be alongside it.
+        - `context_text`: Used in the custom suffix for the test data file name. If `"history_full"`
+          would result in a suffix of `"_history_full.json"`.
+        - `testdata_object_for_write`: The new test data to overwrite the existing test data with.
+    Raises nothing.
+    """
+    testdata_folder_path, testdata_wallet_filename = os.path.split(wallet_path)
+    wallet_basename, _wallet_suffix = os.path.splitext(testdata_wallet_filename)
+    testdata_path = os.path.join(testdata_folder_path, f"{wallet_basename}_{context_text}.json")
+
+    if testdata_object_for_write is not None:
+        with open(testdata_path, "w") as f:
+            json.dump(testdata_object_for_write, f, indent=4)
+
+    assert os.path.exists(testdata_path)
+
+    with open(testdata_path, "r") as f:
+        return json.load(f)

--- a/electrumsv/wallet_database/types.py
+++ b/electrumsv/wallet_database/types.py
@@ -20,6 +20,16 @@ class AccountRow(NamedTuple):
     blockchain_server_id: int | None
     peer_channel_server_id: int | None
 
+class AccountHistoryOutputRow(NamedTuple):
+    tx_hash: bytes
+    txo_index: int
+    script_pubkey_bytes: bytes|None
+    is_mine: bool
+    value: int
+    block_hash: bytes|None
+    block_height: int|None
+    block_position: int|None
+    date_created: int
 
 class AccountTransactionDescriptionRow(NamedTuple):
     account_id: int


### PR DESCRIPTION
…ethods.

- Updated and corrected the `gettransaction` and `listtransactions` documentation which I had misread in the original form.
- Reimplemented the history listing approach from bitcoind as an SQLite database function, in order to lock in understanding and reduce amount of time burned by others in doing the tasks without the database experience I have. This appears to do the core logic correctly, but testing and fleshing out will be enumerated in additional tasks.
- Cleaned up the supplementary json test data file logic used for wallet files.
- Single illustrative unit test for the node API history listing. Fleshing these out will be additional tasks on the node API backlog.