### PR TITLE
Ignore subsequent pushdata notifications

### DIFF
--- a/electrumsv/constants.py
+++ b/electrumsv/constants.py
@@ -633,9 +633,6 @@ class PushDataMatchFlag(IntFlag):
     OUTPUT                                      = 1 << 0
     INPUT                                       = 1 << 1
 
-    # Local flags we set.
-    UNPROCESSED                                 = 1 << 31
-
 
 class ChainWorkerToken(IntEnum):
     MAPI_MESSAGE_CONSUMER                       = 1


### PR DESCRIPTION
- The pushdata notifications pathway is solely used for fetching the rawtx without any consideration given to obtaining the merkle proof - this is done via the output spend notifications pathway.
- Re: issue #904, `read_pushdata_match_metadata` does not require any other flags for filtering. The associated tx_hash being null (or not) is sufficient. Additional flags are redundant.