### PR TITLE
Refactor monitored payment (legacy address payment) to be atomic.

### DIFF
--- a/electrumsv/gui/qt/account_dialog.py
+++ b/electrumsv/gui/qt/account_dialog.py
@@ -50,7 +50,7 @@ class AccountDialog(QDialog):
         name_widget = QLineEdit()
         name_widget.setText(account.display_name())
         name_widget.setReadOnly(True)
-        form.add_row(_("Account name"), name_widget, True)
+        form.add_row(_("Account name"), name_widget)
 
         form.add_row(_("Account type"), QLabel(account.type().value))
         if keystore is not None:

--- a/electrumsv/gui/qt/constants.py
+++ b/electrumsv/gui/qt/constants.py
@@ -8,17 +8,15 @@ ICON_NAME_INVOICE_PAYMENT = "seal"
 
 
 pr_icons = {
-    PaymentFlag.UNPAID: "unpaid.png",
-    PaymentFlag.PAID: "icons8-checkmark-green-52.png",
-    PaymentFlag.EXPIRED: "expired.png"
+    PaymentFlag.STATE_UNPAID: "unpaid.png",
+    PaymentFlag.STATE_PAID: "icons8-checkmark-green-52.png",
+    PaymentFlag.STATE_EXPIRED: "expired.png"
 }
 
 pr_tooltips = {
-    PaymentFlag.UNPAID:_('Unpaid'),
-    PaymentFlag.PAID:_('Paid'),
-    PaymentFlag.EXPIRED:_('Expired'),
-    PaymentFlag.UNKNOWN:_('Unknown'),
-    PaymentFlag.ARCHIVED:_('Archived'),
+    PaymentFlag.STATE_UNPAID:_('Unpaid'),
+    PaymentFlag.STATE_PAID:_('Paid'),
+    PaymentFlag.STATE_EXPIRED:_('Expired'),
 }
 
 

--- a/electrumsv/gui/qt/cosigners_view.py
+++ b/electrumsv/gui/qt/cosigners_view.py
@@ -125,8 +125,8 @@ class CosignerCard(FormSectionWidget):
             QSizePolicy.Policy.MinimumExpanding)
         self._signed_by_label = signed_by_label
 
-        self.add_row(_("Master public key"), key_edit, True)
-        self.add_row(_("Name"), cosigner_name_edit, True)
+        self.add_row(_("Master public key"), key_edit)
+        self.add_row(_("Name"), cosigner_name_edit)
         self.add_row(_("Signed by"), signed_by_label)
 
         self._update_keystore(state.keystore)

--- a/electrumsv/gui/qt/history_list.py
+++ b/electrumsv/gui/qt/history_list.py
@@ -412,7 +412,7 @@ class HistoryList(MyTreeWidget):
                 if row is None:
                     # The associated invoice has been deleted.
                     broadcast_action.setEnabled(False)
-                elif row.flags & PaymentFlag.UNPAID == 0:
+                elif row.flags & PaymentFlag.MASK_STATE == PaymentFlag.STATE_UNPAID:
                     # The associated invoice has already been paid.
                     broadcast_action.setEnabled(False)
                 elif has_expired(row.date_expires):

--- a/electrumsv/gui/qt/invoice_dialog.py
+++ b/electrumsv/gui/qt/invoice_dialog.py
@@ -38,8 +38,8 @@ class InvoiceDialog(WindowModalDialog):
 
         state = row.flags & PaymentFlag.MASK_STATE
         # `EXPIRED` is never stored and solely used for extra visual state.
-        if state & PaymentFlag.UNPAID and has_expired(row.date_expires):
-            state = PaymentFlag.EXPIRED
+        if state == PaymentFlag.STATE_UNPAID and has_expired(row.date_expires):
+            state = PaymentFlag.STATE_EXPIRED
 
         total_amount = 0
         for output in pr.outputs:

--- a/electrumsv/gui/qt/receive_view.py
+++ b/electrumsv/gui/qt/receive_view.py
@@ -125,7 +125,7 @@ class ReceiveView(QWidget):
         # The message box service is required to get mAPI merkle proof callbacks.
         required_flags = NetworkServerFlag.USE_MESSAGE_BOX
         if self._main_window_proxy._wallet.have_wallet_servers(required_flags):
-            self.show_dialog(None, PaymentFlag.INVOICE)
+            self.show_dialog(None, PaymentFlag.TYPE_INVOICE)
             return
 
         dialog_text = _("Receiving invoice payments requires signing up "
@@ -145,7 +145,7 @@ class ReceiveView(QWidget):
         #   selected and connected to.
         # - They chose "Manage servers" which selected and connected to servers and then on exit
         #   from that wizard this dialog auto-accepted.
-        dialog.accepted.connect(partial(self.show_dialog, None, PaymentFlag.INVOICE))
+        dialog.accepted.connect(partial(self.show_dialog, None, PaymentFlag.TYPE_INVOICE))
         dialog.show()
 
 
@@ -155,7 +155,7 @@ class ReceiveView(QWidget):
                 "payment. Please complete that one first."))
             return
 
-        self.show_dialog(None, PaymentFlag.IMPORTED)
+        self.show_dialog(None, PaymentFlag.TYPE_IMPORTED)
 
     def _event_action_triggered_blockchain(self) -> None:
         if None in self._dialogs:
@@ -194,7 +194,7 @@ class ReceiveView(QWidget):
         dialog.show()
 
     def _show_blockchain_payment_dialog(self) -> None:
-        self.show_dialog(None, PaymentFlag.MONITORED)
+        self.show_dialog(None, PaymentFlag.TYPE_MONITORED)
 
     def update_widgets(self) -> None:
         """
@@ -229,7 +229,8 @@ class ReceiveView(QWidget):
         # If the request is an existing one the type should be effectively unspecified.
         assert request_id is None or request_type & PaymentFlag.MASK_TYPE == PaymentFlag.NONE
         # If the request is not an existing one the flag should be a forward looking type.
-        assert request_id is not None or request_type & PaymentFlag.MASK_TYPE != PaymentFlag.LEGACY
+        assert request_id is not None or \
+            request_type & PaymentFlag.MASK_TYPE != PaymentFlag.TYPE_LEGACY
 
         dialog = self._dialogs.get(request_id)
         if dialog is None:

--- a/electrumsv/gui/qt/send_view.py
+++ b/electrumsv/gui/qt/send_view.py
@@ -732,7 +732,7 @@ class SendView(QWidget):
             row = wallet.data.read_invoice_duplicate(pr.get_amount(), pr.get_payment_uri())
             if row is None:
                 row = InvoiceRow(0, account.get_id(), None, pr.get_payment_uri(), pr.get_memo(),
-                    PaymentFlag.UNPAID, pr.get_amount(), pr.to_json().encode(),
+                    PaymentFlag.STATE_UNPAID, pr.get_amount(), pr.to_json().encode(),
                     pr.get_expiration_date())
                 future = wallet.data.create_invoices([ row ])
                 future.add_done_callback(callback)
@@ -745,7 +745,7 @@ class SendView(QWidget):
         pr.set_id(row.invoice_id)
 
         # The invoice is already present. Populate it unless it's paid.
-        if row.flags & PaymentFlag.PAID:
+        if row.flags & PaymentFlag.STATE_PAID:
             self._main_window.show_message("invoice already paid")
             self._payment_request = None
             self.clear()

--- a/electrumsv/gui/qt/util.py
+++ b/electrumsv/gui/qt/util.py
@@ -1251,8 +1251,7 @@ class FormSectionWidget(QWidget):
         else:
             self._frame_layout.addRow(title_object)
 
-    def add_row(self, label_text: Union[str, QLabel], field_object: FieldType,
-            use_separator: bool=True) -> None:
+    def add_row(self, label_text: Union[str, QLabel], field_object: FieldType) -> None:
         """
         Add a row to the form section.
 
@@ -1260,9 +1259,6 @@ class FormSectionWidget(QWidget):
         caller can use that and helper functions to dynamically alter the form section display
         as needed (hide, show, ..).
         """
-        if use_separator and self._frame_layout.count() > 0:
-            self._frame_layout.addRow(FormSeparatorLine())
-
         if isinstance(label_text, QLabel):
             label = label_text
             label_text = label.text()
@@ -1274,6 +1270,11 @@ class FormSectionWidget(QWidget):
         label.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
 
         self._frame_layout.addRow(label, field_object)
+
+    def set_row_visible_for_object(self, field_object: FieldType, flag: bool) -> None:
+        # NOTE(typing) We use the custom PyQt6-stubs project to provide type bindings for Qt6 and
+        #     it is rarely updated and does not seem to include this change added in Qt 6.4.
+        self._frame_layout.setRowVisible(field_object, flag) # type: ignore[attr-defined]
 
     def clear(self, have_layout: bool=True) -> None:
         if have_layout and self._frame_layout is not None:

--- a/electrumsv/network_support/direct_payments.py
+++ b/electrumsv/network_support/direct_payments.py
@@ -8,10 +8,9 @@ import json
 from typing import TypedDict
 
 from ..app_state import app_state
+from ..constants import DPPMessageType
 from ..dpp_messages import HPMPaymentACK, HYBRID_PAYMENT_MODE_BRFCID, Payment, PaymentACK, \
     PeerChannelDict, PaymentACKDict
-from .dpp_proxy import MSG_TYPE_PAYMENT_REQUEST_RESPONSE, MSG_TYPE_PAYMENT_ACK, \
-    MSG_TYPE_PAYMENT_REQUEST_ERROR, MSG_TYPE_PAYMENT_ERROR
 from ..exceptions import Bip270Exception
 from ..logs import logs
 from ..networks import Net
@@ -134,7 +133,7 @@ def dpp_make_payment_request_response(server_url: str, credential_id: Indefinite
         expiration=message_row_received.expiration,
         body=json.dumps(response_json).encode('utf-8'),
         timestamp=datetime.now(tz=timezone.utc).isoformat(),
-        type=MSG_TYPE_PAYMENT_REQUEST_RESPONSE
+        type=DPPMessageType.REQUEST_RESPONSE
     )
     return message_row_response
 
@@ -156,7 +155,7 @@ def dpp_make_ack(txid: str, peer_channel: PeerChannelDict,
         expiration=message_row_received.expiration,
         body=json.dumps(payment_ack_data).encode('utf-8'),
         timestamp=datetime.now(tz=timezone.utc).isoformat(),
-        type=MSG_TYPE_PAYMENT_ACK)
+        type=DPPMessageType.PAYMENT_ACK)
     return message_row_response
 
 
@@ -176,7 +175,7 @@ def dpp_make_payment_request_error(message_row_received: DPPMessageRow, error_re
         expiration=message_row_received.expiration,
         body=json.dumps(client_error).encode('utf-8'),
         timestamp=datetime.now(tz=timezone.utc).isoformat(),
-        type=MSG_TYPE_PAYMENT_REQUEST_ERROR)
+        type=DPPMessageType.REQUEST_ERROR)
     return message_row_response
 
 
@@ -196,6 +195,6 @@ def dpp_make_payment_error(message_row_received: DPPMessageRow, error_reason: st
         expiration=message_row_received.expiration,
         body=json.dumps(client_error).encode('utf-8'),
         timestamp=datetime.now(tz=timezone.utc).isoformat(),
-        type=MSG_TYPE_PAYMENT_ERROR)
+        type=DPPMessageType.PAYMENT_ERROR)
     return message_row_response
 

--- a/electrumsv/network_support/general_api.py
+++ b/electrumsv/network_support/general_api.py
@@ -1052,6 +1052,9 @@ async def _manage_tip_filter_registrations_async(state: ServerConnectionState) -
 async def create_tip_filter_registration_async(state: ServerConnectionState,
         pushdata_hash: bytes, date_expires: int, keyinstance_id: int,
         script_type: ScriptType) -> TipFilterRegistrationJob:
+    """
+    Raises nothing.
+    """
     # The reference server needs to be updated to take a UTC expiry date.
     expiry_seconds = date_expires - int(time.time())
     job = TipFilterRegistrationJob([

--- a/electrumsv/tests/test_account.py
+++ b/electrumsv/tests/test_account.py
@@ -5,15 +5,18 @@ import unittest.mock
 import pytest
 
 from electrumsv.constants import (AccountFlags, CHANGE_SUBPATH, KeyInstanceFlag, KeystoreTextType,
-    RECEIVING_SUBPATH, ScriptType)
+    PaymentFlag, RECEIVING_SUBPATH, ScriptType, ServerConnectionFlag)
+from electrumsv.exceptions import NoViableServersError, ServiceUnavailableError
 from electrumsv.keystore import BIP32_KeyStore, instantiate_keystore_from_text
+from electrumsv.network_support.types import TipFilterRegistrationJob, \
+    TipFilterRegistrationJobOutput
 from electrumsv.wallet import StandardAccount, Wallet
 from electrumsv.wallet_database.exceptions import KeyInstanceNotFoundError
 from electrumsv.wallet_database.types import AccountRow
 from electrumsv.storage import WalletStorage
 
-from .util import _create_mock_app_state, mock_headers, MockStorage, PasswordToken, setup_async, \
-    tear_down_async
+from .util import _create_mock_app_state, mock_headers, MockStorage, setup_async, tear_down_async
+from ..network_support.types import ServerConnectionState
 
 
 def setUpModule():
@@ -148,3 +151,92 @@ async def test_key_reservation(mock_app_state1, mock_app_state2) -> None:
     assert KeyInstanceFlag(keyinstance1.flags) == KeyInstanceFlag.USED
     assert KeyInstanceFlag(keyinstance2.flags) == (KeyInstanceFlag.ACTIVE | KeyInstanceFlag.USED |
         KeyInstanceFlag.IS_PAYMENT_REQUEST)
+
+
+# TODO(technical-debt) Pre-created test wallets. Have a pre-created wallet with an account.
+@pytest.mark.asyncio
+@unittest.mock.patch(
+    'electrumsv.wallet.create_tip_filter_registration_async')
+@unittest.mock.patch(
+    "electrumsv.wallet_database.migrations.migration_0029_reference_server.app_state")
+@unittest.mock.patch('electrumsv.wallet.app_state', new_callable=_create_mock_app_state)
+async def test_create_monitored_blockchain_payment_async(mock_app_state1, mock_app_state2,
+        create_tip_filter_registration_async) -> None:
+    """
+    Verify that the allocate a key on demand database function works as expected for an account.
+    """
+    password = 'password'
+    mock_app_state1.credentials.get_wallet_password = lambda wallet_path: password
+    mock_app_state2.headers = mock_headers()
+
+    tmp_storage = cast(WalletStorage, MockStorage(password))
+    # Boilerplate setting up of a deterministic account. This is copied from above.
+    seed_words = 'cycle rocket west magnet parrot shuffle foot correct salt library feed song'
+    child_keystore = cast(BIP32_KeyStore, instantiate_keystore_from_text(
+        KeystoreTextType.ELECTRUM_SEED_WORDS, seed_words, password))
+
+    wallet = Wallet(tmp_storage)
+    masterkey_row = wallet.create_masterkey_from_keystore(child_keystore)
+
+    raw_account_row = AccountRow(-1, masterkey_row.masterkey_id, ScriptType.P2PKH, '...',
+        AccountFlags.NONE, None, None)
+    account_row = wallet.add_accounts([ raw_account_row ])[0]
+    account = StandardAccount(wallet, account_row)
+    wallet.register_account(account.get_id(), account)
+
+    # Ensure there is an expiry date passed.
+    with pytest.raises(AssertionError):
+        await account.create_monitored_blockchain_payment_async(None, None, None, None)
+
+    expiry_date = 100
+    wallet.get_connection_state_for_usage = lambda *args: None
+    with pytest.raises(NoViableServersError):
+        await account.create_monitored_blockchain_payment_async(None, None, None, expiry_date)
+
+    server_state = unittest.mock.Mock(spec=ServerConnectionState)
+    server_state.connection_flags = ServerConnectionFlag.NONE
+    wallet.get_connection_state_for_usage = lambda *args: server_state
+    with pytest.raises(ServiceUnavailableError):
+        await account.create_monitored_blockchain_payment_async(None, None, None, expiry_date)
+
+    # We mock out the queued server registration.
+    our_job_output = TipFilterRegistrationJobOutput()
+    our_job_output.date_registered=11111
+    our_job_output.completed_event.set()
+    async def fake_create_tip_filter_registration_async(state: ServerConnectionState,
+            pushdata_hash: bytes, date_expires: int, keyinstance_id: int,
+            script_type: ScriptType) -> TipFilterRegistrationJob:
+        nonlocal our_job_output
+        return TipFilterRegistrationJob([], our_job_output)
+
+    # TEST: Successful result.
+    server_state.connection_flags = ServerConnectionFlag.TIP_FILTER_READY
+    create_tip_filter_registration_async.side_effect = fake_create_tip_filter_registration_async
+    paymentrequest_row1, paymentrequest_output_rows1, their_job_output = \
+        await account.create_monitored_blockchain_payment_async(10000, None, None, expiry_date)
+    assert their_job_output.date_registered == 11111
+    assert their_job_output.failure_reason is None
+    assert paymentrequest_row1 is not None
+    assert paymentrequest_row1.request_flags & PaymentFlag.MASK_STATE == PaymentFlag.STATE_UNPAID
+    assert paymentrequest_row1.request_flags & PaymentFlag.MASK_TYPE == PaymentFlag.TYPE_MONITORED
+    assert len(paymentrequest_output_rows1) == 1
+
+    # TEST: Unsuccessful result.
+    our_job_output.date_registered = None
+    our_job_output.failure_reason = "would be error text"
+    create_tip_filter_registration_async.side_effect = fake_create_tip_filter_registration_async
+    paymentrequest_row2, paymentrequest_output_rows2, their_job_output = \
+        await account.create_monitored_blockchain_payment_async(10000, None, None, expiry_date)
+    assert their_job_output.date_registered is None
+    assert their_job_output.failure_reason == "would be error text"
+    assert paymentrequest_row2 is None
+    assert len(paymentrequest_output_rows2) == 0
+
+    # The unsuccessful entry should have had it's payment request deleted.
+    read_request_rows = sorted(wallet.data.read_payment_requests(),
+        key=lambda read_request_row: read_request_row.paymentrequest_id)
+    assert len(read_request_rows) == 2
+    assert read_request_rows[0].paymentrequest_id == paymentrequest_row1.paymentrequest_id
+    assert read_request_rows[0].request_flags & PaymentFlag.MASK_HIDDEN == PaymentFlag.NONE
+    assert read_request_rows[1].paymentrequest_id == paymentrequest_row1.paymentrequest_id+1
+    assert read_request_rows[1].request_flags & PaymentFlag.MASK_HIDDEN == PaymentFlag.DELETED

--- a/electrumsv/wallet_database/types.py
+++ b/electrumsv/wallet_database/types.py
@@ -3,11 +3,11 @@ import dataclasses
 from datetime import datetime, timezone
 from typing import Any, NamedTuple, Protocol
 
-from ..constants import (AccountFlags, AccountTxFlags, DerivationType, KeyInstanceFlag,
-    MAPIBroadcastFlag, MasterKeyFlags, NetworkServerFlag, NetworkServerType, PaymentFlag,
-    PeerChannelAccessTokenFlag, PeerChannelMessageFlag, PushDataMatchFlag,
-    PushDataHashRegistrationFlag, ScriptType,
-    ServerPeerChannelFlag, TransactionOutputFlag, TxFlags, WalletEventFlag, WalletEventType)
+from ..constants import (AccountFlags, AccountTxFlags, DerivationType, DPPMessageType,
+    KeyInstanceFlag, MAPIBroadcastFlag, MasterKeyFlags, NetworkServerFlag, NetworkServerType,
+    PaymentFlag, PeerChannelAccessTokenFlag, PeerChannelMessageFlag, PushDataMatchFlag,
+    PushDataHashRegistrationFlag, ScriptType, ServerPeerChannelFlag, TransactionOutputFlag,
+    TxFlags, WalletEventFlag, WalletEventType)
 from ..types import MasterKeyDataTypes
 
 
@@ -199,7 +199,8 @@ class PushDataRegistrationRow(NamedTuple):
 class PaymentRequestRow(NamedTuple):
     # This is `None` for the `INSERT` as this makes SQLite allocate the primary key value for us.
     paymentrequest_id: int | None
-    state: PaymentFlag
+    # This is badly named, should be `request_flags`.
+    request_flags: PaymentFlag
     requested_value: int | None
     date_expires: int | None
     # The local label we apply to transactions (seen in the history tab) received.
@@ -630,7 +631,7 @@ class DPPMessageRow(NamedTuple):
     expiration: int | None
     body: bytes
     timestamp: str
-    type: str
+    type: DPPMessageType
 
     def to_json(self, ) -> str:
         ts = datetime.now(tz=timezone.utc).isoformat().replace('+00:00', 'Z')


### PR DESCRIPTION
- The payment request is in a `STATE_PREPARING` until it has had the remote tip filter registration successfully put in place.
- We clean up leaked payment requests that are more than 2 days old on startup. This should not happen unless the wallet is killed mid-registration.
- Larger refactoring of constants.
- This was tested with both legacy payments and DPP invoices, and both worked. The UI was not updated comprehensively (i.e. if you had the receive dialog open it would not reflect paid state) and this is something for the backlog.