### PR TITLE
Fix `map_transaction_output_key_usage` as it was not generating the p…

### DIFF
--- a/electrumsv/wallet_support/keys.py
+++ b/electrumsv/wallet_support/keys.py
@@ -140,7 +140,7 @@ def map_transaction_output_key_usage(transaction: Transaction,
                 script_template.public_keys }
         elif isinstance(script_template, P2PK_Output):
             script_type = ScriptType.P2PK
-            pushdata_hashes = { script_template.hash160() }
+            pushdata_hashes = { sha256(script_template.public_key.to_bytes()) }
         elif isinstance(script_template, P2PKH_Address):
             script_type = ScriptType.P2PKH
             pushdata_hashes = { sha256(script_template.hash160()) }


### PR DESCRIPTION
…ushdata hash correctly for the P2PK case

**Symptoms**
When performing an initial blockchain scan (seed based restoration) for the non-mining regtest wallet with seed phrase: `neutral cash ozone buyer cook match exhaust usual purse transfer evil believe`, there is a bug whereby only one transaction is shown in the history tab instead of three. All three transactions are imported but only one is displayed in the UI.

On the second re-scan attempt, it picks up the 2nd transaction. 

On the 3rd attempt it still continues to fail to pick up the 3rd transaction (which has a P2PK type output script - tx_hash: 88c92bb09626c7d505ed861ae8fa7e7aaab5b816fc517eac7a8a6c7f28b1b210 The relevant pushdata hash is 04bca2ae277997940152716854a95347819c2e07d370d22c093b39708fb9d5eb

**Diagnosis**
The `map_transaction_output_key_usage` function has a bug in it where it does not correctly calculate the pushdata hash for P2PK type scripts.
This in turn leads to the `TransactionOutputs` table having a null  `keyinstance_id` which in turn leads to a missing `TransactionValues` table view.

**Fix**
Fixing the `map_transaction_output_key_usage` function results in the correct propagation of the `keyinstance_id` and all three transactions are displayed as they should be.