### PR TITLE
The header chain state writing was not working reliably. It was using…

### DIFF
--- a/electrumsv/cached_headers.py
+++ b/electrumsv/cached_headers.py
@@ -241,7 +241,7 @@ def write_cached_headers(headers: Headers) -> None:
         flush_headers_object(headers)
 
     headers_path = headers._storage.filename
-    headerfile_size = headers._storage.reserved_size + headers._storage.header_count * 80
+    headerfile_size = headers._storage.reserved_size + len(headers._storage) * 80
     headerfile_hash = hash_headerfile(headers_path, headerfile_size)
 
     chaindata_filename = headers_path +".chain_data"

--- a/electrumsv/tests/test_cached_headers.py
+++ b/electrumsv/tests/test_cached_headers.py
@@ -242,10 +242,10 @@ def test_incremental_update(make_regtest_headers_copy: Callable[[str|None], Head
             # Verify that the extended headers are present, but the chain data knows it's
             # state is only up to the pre-extension header index. The incremental read that
             # we are intercepting will process the outstanding headers.
-            assert local_headers2._storage.header_count == 1 + 115 + 10
+            assert len(local_headers2._storage) == 1 + 115 + 10
             assert last_index == 115
             original_read_unprocessed_headers(local_headers2, last_index)
-            assert local_headers2._storage.header_count == 1 + 115 + 10
+            assert len(local_headers2._storage) == 1 + 115 + 10
         mock_read_file.side_effect = mocked_read_unprocessed_headers
 
         # This should be a full processed copy of the double chain headers store.


### PR DESCRIPTION
… the

cached `header_count` variable which does not get updated when the underlying mmap field gets updated and reflected the state on headers file load not the active state.