### PR TITLE
Add a github action trigger so that any new commits to the develop or…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Trigger Build
+on:
+  push:
+    branches:
+      - releases/1.3
+      - develop
+    pull_request:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.PAT }}
+        repository: electrumsv/electrumsv-build
+        event-type: new-commit
+        client-payload: '{"branch": "${{ github.ref_name }}"}'


### PR DESCRIPTION
… releases/1.3 branches will trigger running the electrumsv/electrumsv-build pipeline

- For this to work, the repository-dispatch@v1 action requires a personal access token (PAT). I have generated a personal access token from user account "AustEcon" and included it in the ElectrumSV repo as a github "secret" named "PAT"