### PR TITLE
To install hidapi==0.10.0 on linux (which requires building from sour…

### DIFF
--- a/.azure-pipelines/prepare-general-environment.yml
+++ b/.azure-pipelines/prepare-general-environment.yml
@@ -15,6 +15,8 @@ steps:
 - script: |
     sudo apt-get update
     sudo apt-get install libusb-1.0-0-dev libudev-dev
+    python3 -m pip install cython==0.29.36
+    python3 -m pip install wheel
     python3 -m pip install -r contrib/deterministic-build/linux-py3.9-requirements-dev.txt --disable-pip-version-check
     python3 -m pip install pysqlite3-binary --disable-pip-version-check
     # There is some poor quality issues with pip and it erroring with vague and completely

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,8 @@ MacOS::
 Linux::
 
     sudo apt-get install python3-pyqt5
+    pip3 install wheel
+    pip3 install cython==0.29.36
     pip3 install --user -r contrib/deterministic-build/linux-py3.9-requirements-electrumsv.txt
 
 Your should now be able to run ElectrumSV::
@@ -140,7 +142,7 @@ Errors relating to "libusb" installing the pip3 requirements
 
 Install the following::
 
-    sudo apt install libusb-1.0.0-dev libudev-dev
+    sudo apt-get install libusb-1.0.0-dev libudev-dev
 
 Errors relating to "Python.h"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
…ce) for python3.9.x it requires cython==0.29.x