### PR TITLE
Fix network server deletion and addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,7 @@ libzbar-0.dll
 # Mypy
 .mypy*
 *.log
-electrum_sv_data
-electrum_sv_data/regtest/*
+electrum_sv_data/*
 electrumsv1/*
 contrib/functional_tests/stresstesting/.benchmarks/*
 electrum-sv-regtest.py

--- a/electrumsv/network_support/general_api.py
+++ b/electrumsv/network_support/general_api.py
@@ -1296,7 +1296,7 @@ async def prepare_server_tip_filter_peer_channel(indexing_server_state: ServerCo
     # NOTE(typing) Type is incompatible with same type, who knows? Error message as follows:
     # `Argument 1 to "update" of "TypedDict" has incompatible type "IndexerServerSettings";
     # expected "TypedDict({'tipFilterCallbackUrl'?: str | None})"  [typeddict-item]`
-    indexing_server_state.indexer_settings.update(settings_delta_object) # type: ignore
+    indexing_server_state.indexer_settings.update(settings_delta_object)
     if settings_object != indexing_server_state.indexer_settings:
         # TODO(1.4.0) Unreliable server, issue#841. Differing server indexer settings after setup.
         #     Server unreliability case OR user unreliability with clashing wallets open using

--- a/electrumsv/network_support/headers.py
+++ b/electrumsv/network_support/headers.py
@@ -79,8 +79,8 @@ async def get_chain_tips_async(server_state: HeaderServerState, session: aiohttp
                 raise ServiceUnavailableError("The Header API is not enabled for this server")
 
             if response.status != http.HTTPStatus.OK:
-                error_message = f"get_chain_tips failed with status: {response.status}, " \
-                                f"reason: {response.reason}"
+                error_message = f"get_chain_tips failed for {url} with status: " \
+                                f"{response.status}, reason: {response.reason}"
                 logger.error(error_message)
                 raise HeaderResponseError(error_message)
 

--- a/electrumsv/wallet.py
+++ b/electrumsv/wallet.py
@@ -3251,6 +3251,7 @@ class Wallet:
             for specific_server_key in deleted_server_keys:
                 server = self._servers[specific_server_key.to_base_key()]
                 server.clear_server_account_usage(specific_server_key)
+                del self._servers[specific_server_key.to_base_key()]
 
         # The `added_server_rows` do not yet have an assigned primary key value, and are not
         # representative of the actual added rows.


### PR DESCRIPTION
- The server was not being removed from the `Wallet._servers` cache on deletion which resulted in a `KeyError` in `ServersTab.update_servers()` at the line: `flags = server.database_rows[None].server_flags`
- When adding a new server the url was being saved without a trailing "/". This breaks assertions expecting there to always be a trailing "/" for all network servers.