### PR TITLE
Fix a bug where a socket connection to "bsv.aftrek.org" is successful…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ Pipfile
 Pipfile.lock
 
 # local data directories
-electrum_sv_data/regtest/*
+electrum_sv_data/*
 instance_*

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -153,7 +153,7 @@ class DisconnectSessionError(Exception):
 
     def __init__(self, reason, *, blacklist=False):
         super().__init__(reason)
-        self.blacklist = False
+        self.blacklist = blacklist
 
 
 class SVServerState:

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -465,7 +465,7 @@ class SVSession(RPCSession):
             self.logger.debug(f'negotiated protocol: {protocol_string}')
             self.ptuple = protocol_tuple(protocol_string)
             assert PROTOCOL_MIN <= self.ptuple <= PROTOCOL_MAX
-        except (AssertionError, ValueError) as e:
+        except (AssertionError, TypeError, ValueError) as e:
             raise DisconnectSessionError(f'{method} failed: {e}', blacklist=True)
 
     async def _get_checkpoint_headers(self):

--- a/electrumsv/network.py
+++ b/electrumsv/network.py
@@ -461,9 +461,12 @@ class SVSession(RPCSession):
         args = (PACKAGE_VERSION, [ version_string(PROTOCOL_MIN), version_string(PROTOCOL_MAX) ])
         try:
             server_string, protocol_string = await self.send_request(method, args)
+            assert isinstance(server_string, str)
+            assert isinstance(protocol_string, str)
             self.logger.debug(f'server string: {server_string}')
             self.logger.debug(f'negotiated protocol: {protocol_string}')
             self.ptuple = protocol_tuple(protocol_string)
+            assert len(self.ptuple) in (2, 3)
             assert PROTOCOL_MIN <= self.ptuple <= PROTOCOL_MAX
         except (AssertionError, TypeError, ValueError) as e:
             raise DisconnectSessionError(f'{method} failed: {e}', blacklist=True)

--- a/electrumsv/tests/test_util.py
+++ b/electrumsv/tests/test_util.py
@@ -1,7 +1,7 @@
 import pytest
 import unittest
 
-from electrumsv.util import format_satoshis, get_identified_release_signers
+from electrumsv.util import format_satoshis, get_identified_release_signers, protocol_tuple
 from electrumsv.util.cache import LRUCache
 
 from .conftest import get_tx_datacarrier_size, get_tx_small_size
@@ -12,6 +12,38 @@ SIZEOF_TEST_TX_SMALL = get_tx_small_size()
 
 
 class TestUtil(unittest.TestCase):
+    def test_protocol_tuple(self):
+        bad_input1 = ""
+        bad_input2 = "..."
+        bad_input3 = 100
+        bad_input4 = [1, 4, 2]
+        bad_input5 = 1.4
+        bad_input6 = (1, 4, 2)
+        bad_input7 = "letters"
+        bad_input8 = None
+
+        good_input1 = "1.4.2"
+        good_input2 = "1.4"
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input1)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input2)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input3)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input4)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input5)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input6)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input7)
+        with pytest.raises(ValueError):
+            protocol_tuple(bad_input8)
+
+        assert protocol_tuple(good_input1) == (1, 4, 2)
+        assert protocol_tuple(good_input2) == (1, 4)
+
     def test_format_satoshis(self):
         result = format_satoshis(1234)
         expected = "0.00001234"


### PR DESCRIPTION
…ly established but on protocol negotiation, the result is "None"

- This crashes the entire asyncio event loop with "TypeError: cannot unpack non-iterable NoneType object"

Context:

This is the relevant traceback:

```
2023-08-10 12:43:42,021:ERROR:async:async task raised an unhandled exception
Traceback (most recent call last):
  File ".../electrumsv/electrumsv/async_.py", line 94, in _collect
    future.result()
  File ".../.pyenv/versions/3.9.16/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File ".../.pyenv/versions/3.9.16/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File ".../electrumsv/electrumsv/network.py", line 944, in _main_task
    await group.spawn(self._monitor_wallets, group)
  File ".../electrumsv/lib/python3.9/site-packages/aiorpcx/curio.py", line 255, in aexit
    await self.join()
  File ".../electrumsv/lib/python3.9/site-packages/aiorpcx/curio.py", line 213, in join
    raise task.exception()
  File ".../electrumsv/electrumsv/network.py", line 973, in _maintain_connections
    await group.spawn(self._maintain_connection, n)
  File ".../electrumsv/lib/python3.9/site-packages/aiorpcx/curio.py", line 255, in aexit
    await self.join()
  File ".../electrumsv/lib/python3.9/site-packages/aiorpcx/curio.py", line 213, in join
    raise task.exception()
  File ".../electrumsv/electrumsv/network.py", line 987, in _maintain_connection
    await server.connect(self, n)
  File "...electrumsv/electrumsv/network.py", line 266, in connect
    await session.run()
  File ".../electrumsv/electrumsv/network.py", line 763, in run
    await self._negotiate_protocol()
  File ".../electrumsv/electrumsv/network.py", line 463, in _negotiate_protocol
    server_string, protocol_string = await self.send_request(method, args)
TypeError: cannot unpack non-iterable NoneType object
```

This only occurs for the "bsv.aftrek.org" server and is strange because we've never encountered this behaviour from any ElectrumX server in the past.

To reproduce this in isolation sheds some light:

```
import asyncio
import aiorpcx
import ssl

async def main(host, port):
    async with aiorpcx.connect_rs(host, port, ssl=ssl.SSLContext(ssl.PROTOCOL_TLS)) as session:
        print("Connected!")
        result = await session.send_request('server.version', ("1.3.16", ["1.4", "1.4.2"]))
        print(result)

asyncio.run(main('sv3.satoshi.io', 50002))
asyncio.run(main('bsv.aftrek.org', 50002))
```
Console output:
```
Connected!
['ElectrumX 1.20.2', '1.4.2']
Connected!
None
```

So a connection is still being established to bsv.aftrek.org but for some reason protocol negotiation is failing.